### PR TITLE
fix: query encoding issue

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -45,6 +45,9 @@ paths:
                       type: string
                     total_validator_shares:
                       type: string
+                    reward_start_time:
+                      type: string
+                      format: date-time
                   title: 'key: denom value: AllianceAsset'
               pagination:
                 type: object
@@ -151,6 +154,73 @@ paths:
           type: boolean
       tags:
         - Query
+  '/terra/alliances/ibc/{hash}':
+    get:
+      summary: Query a specific alliance by ibc hash
+      operationId: AllianceAllianceIBCAlliance
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              alliance:
+                type: object
+                properties:
+                  denom:
+                    type: string
+                    title: >-
+                      Denom of the asset. It could either be a native token or
+                      an IBC token
+                  reward_weight:
+                    type: string
+                    description: >-
+                      The reward weight specifies the ratio of rewards that will
+                      be given to each alliance asset
+
+                      It does not need to sum to 1. rate = weight / total_weight
+
+                      Native asset is always assumed to have a weight of 1.
+                  take_rate:
+                    type: string
+                    title: >-
+                      A positive take rate is used for liquid staking
+                      derivatives. It defines an annualized reward rate that
+
+                      will be redirected to the distribution rewards pool
+                  total_tokens:
+                    type: string
+                  total_validator_shares:
+                    type: string
+                  reward_start_time:
+                    type: string
+                    format: date-time
+                title: 'key: denom value: AllianceAsset'
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                  additionalProperties: {}
+      parameters:
+        - name: hash
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
   /terra/alliances/params:
     get:
       operationId: AllianceAllianceParams
@@ -194,7 +264,123 @@ paths:
                   additionalProperties: {}
       tags:
         - Query
-  '/terra/alliances/{delegator_addr_1}/{validator_addr}/{denom}':
+  '/terra/alliances/rewards/{delegator_addr}/{validator_addr}/ibc/{hash}':
+    get:
+      summary: 'Query for rewards by delegator addr, validator_addr and denom'
+      operationId: AllianceAllianceIBCAllianceDelegationRewards
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              rewards:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    denom:
+                      type: string
+                    amount:
+                      type: string
+                  description: >-
+                    Coin defines a token with a denomination and an amount.
+
+
+                    NOTE: The amount field is an Int which implements the custom
+                    method
+
+                    signatures required by gogoproto.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                  additionalProperties: {}
+      parameters:
+        - name: delegator_addr
+          in: path
+          required: true
+          type: string
+        - name: validator_addr
+          in: path
+          required: true
+          type: string
+        - name: hash
+          in: path
+          required: true
+          type: string
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  '/terra/alliances/rewards/{delegator_addr}/{validator_addr}/{denom}':
     get:
       summary: 'Query for rewards by delegator addr, validator_addr and denom'
       operationId: AllianceAllianceAllianceDelegationRewards
@@ -240,7 +426,7 @@ paths:
                       type: string
                   additionalProperties: {}
       parameters:
-        - name: delegator_addr_1
+        - name: delegator_addr
           in: path
           required: true
           type: string
@@ -344,7 +530,7 @@ paths:
                         shares:
                           type: string
                           description: shares define the delegation shares received.
-                        reward_indices:
+                        reward_history:
                           type: array
                           items:
                             type: object
@@ -353,6 +539,9 @@ paths:
                                 type: string
                               index:
                                 type: string
+                        last_reward_claim_height:
+                          type: string
+                          format: uint64
                     balance:
                       type: object
                       properties:
@@ -519,7 +708,7 @@ paths:
                         shares:
                           type: string
                           description: shares define the delegation shares received.
-                        reward_indices:
+                        reward_history:
                           type: array
                           items:
                             type: object
@@ -528,6 +717,9 @@ paths:
                                 type: string
                               index:
                                 type: string
+                        last_reward_claim_height:
+                          type: string
+                          format: uint64
                     balance:
                       type: object
                       properties:
@@ -662,6 +854,162 @@ paths:
           type: boolean
       tags:
         - Query
+  '/terra/alliances/{delegator_addr}/{validator_addr}/ibc/{hash}':
+    get:
+      summary: >-
+        Query a delegation to an alliance by delegator addr, validator_addr and
+        denom
+      operationId: AllianceAllianceIBCAllianceDelegation
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              delegation:
+                type: object
+                properties:
+                  delegation:
+                    type: object
+                    properties:
+                      delegator_address:
+                        type: string
+                        description: >-
+                          delegator_address is the bech32-encoded address of the
+                          delegator.
+                      validator_address:
+                        type: string
+                        description: >-
+                          validator_address is the bech32-encoded address of the
+                          validator.
+                      denom:
+                        type: string
+                        title: denom of token staked
+                      shares:
+                        type: string
+                        description: shares define the delegation shares received.
+                      reward_history:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            denom:
+                              type: string
+                            index:
+                              type: string
+                      last_reward_claim_height:
+                        type: string
+                        format: uint64
+                  balance:
+                    type: object
+                    properties:
+                      denom:
+                        type: string
+                      amount:
+                        type: string
+                    description: >-
+                      Coin defines a token with a denomination and an amount.
+
+
+                      NOTE: The amount field is an Int which implements the
+                      custom method
+
+                      signatures required by gogoproto.
+                description: >-
+                  DelegationResponse is equivalent to Delegation except that it
+                  contains a
+
+                  balance in addition to shares which is more suitable for
+                  client responses.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                  additionalProperties: {}
+      parameters:
+        - name: delegator_addr
+          in: path
+          required: true
+          type: string
+        - name: validator_addr
+          in: path
+          required: true
+          type: string
+        - name: hash
+          in: path
+          required: true
+          type: string
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
   '/terra/alliances/{delegator_addr}/{validator_addr}/{denom}':
     get:
       summary: >-
@@ -696,7 +1044,7 @@ paths:
                       shares:
                         type: string
                         description: shares define the delegation shares received.
-                      reward_indices:
+                      reward_history:
                         type: array
                         items:
                           type: object
@@ -705,6 +1053,9 @@ paths:
                               type: string
                             index:
                               type: string
+                      last_reward_claim_height:
+                        type: string
+                        format: uint64
                   balance:
                     type: object
                     properties:
@@ -853,6 +1204,9 @@ paths:
                     type: string
                   total_validator_shares:
                     type: string
+                  reward_start_time:
+                    type: string
+                    format: date-time
                 title: 'key: denom value: AllianceAsset'
         default:
           description: An unexpected error response.
@@ -45023,6 +45377,9 @@ definitions:
         type: string
       total_validator_shares:
         type: string
+      reward_start_time:
+        type: string
+        format: date-time
     title: 'key: denom value: AllianceAsset'
   alliance.alliance.Delegation:
     type: object
@@ -45039,7 +45396,7 @@ definitions:
       shares:
         type: string
         description: shares define the delegation shares received.
-      reward_indices:
+      reward_history:
         type: array
         items:
           type: object
@@ -45048,6 +45405,9 @@ definitions:
               type: string
             index:
               type: string
+      last_reward_claim_height:
+        type: string
+        format: uint64
   alliance.alliance.DelegationResponse:
     type: object
     properties:
@@ -45066,7 +45426,7 @@ definitions:
           shares:
             type: string
             description: shares define the delegation shares received.
-          reward_indices:
+          reward_history:
             type: array
             items:
               type: object
@@ -45075,6 +45435,9 @@ definitions:
                   type: string
                 index:
                   type: string
+          last_reward_claim_height:
+            type: string
+            format: uint64
       balance:
         type: object
         properties:
@@ -45104,6 +45467,28 @@ definitions:
     type: object
   alliance.alliance.MsgUpdateAllianceResponse:
     type: object
+  alliance.alliance.NewAllianceAssetMsg:
+    type: object
+    properties:
+      denom:
+        type: string
+        title: Denom of the asset. It could either be a native token or an IBC token
+      reward_weight:
+        type: string
+        description: >-
+          The reward weight specifies the ratio of rewards that will be given to
+          each alliance asset
+
+          It does not need to sum to 1. rate = weight / total_weight
+
+          Native asset is always assumed to have a weight of 1.
+      take_rate:
+        type: string
+        title: >-
+          A positive take rate is used for liquid staking derivatives. It
+          defines an annualized reward rate that
+
+          will be redirected to the distribution rewards pool
   alliance.alliance.Params:
     type: object
     properties:
@@ -45141,7 +45526,7 @@ definitions:
               shares:
                 type: string
                 description: shares define the delegation shares received.
-              reward_indices:
+              reward_history:
                 type: array
                 items:
                   type: object
@@ -45150,6 +45535,9 @@ definitions:
                       type: string
                     index:
                       type: string
+              last_reward_claim_height:
+                type: string
+                format: uint64
           balance:
             type: object
             properties:
@@ -45219,6 +45607,9 @@ definitions:
             type: string
           total_validator_shares:
             type: string
+          reward_start_time:
+            type: string
+            format: date-time
         title: 'key: denom value: AllianceAsset'
   alliance.alliance.QueryAlliancesDelegationsResponse:
     type: object
@@ -45247,7 +45638,7 @@ definitions:
                 shares:
                   type: string
                   description: shares define the delegation shares received.
-                reward_indices:
+                reward_history:
                   type: array
                   items:
                     type: object
@@ -45256,6 +45647,9 @@ definitions:
                         type: string
                       index:
                         type: string
+                last_reward_claim_height:
+                  type: string
+                  format: uint64
             balance:
               type: object
               properties:
@@ -45336,6 +45730,9 @@ definitions:
               type: string
             total_validator_shares:
               type: string
+            reward_start_time:
+              type: string
+              format: date-time
           title: 'key: denom value: AllianceAsset'
       pagination:
         type: object
@@ -45378,7 +45775,7 @@ definitions:
             type: string
             format: date-time
             title: Last application of `take_rate` on assets
-  alliance.alliance.RewardIndex:
+  alliance.alliance.RewardHistory:
     type: object
     properties:
       denom:

--- a/proto/alliance/query.proto
+++ b/proto/alliance/query.proto
@@ -26,6 +26,11 @@ service Query {
     option (google.api.http).get = "/terra/alliances/{denom}";
   }
 
+  // Query a specific alliance by ibc hash
+  rpc IBCAlliance(QueryIBCAllianceRequest) returns (QueryAllianceResponse) {
+    option (google.api.http).get = "/terra/alliances/ibc/{hash}";
+  }
+
   // Query all paginated alliance delegations for a delegator addr
   rpc AlliancesDelegation(QueryAlliancesDelegationsRequest) returns (QueryAlliancesDelegationsResponse) {
     option (google.api.http).get = "/terra/alliances/{delegator_addr}";
@@ -41,9 +46,18 @@ service Query {
     option (google.api.http).get = "/terra/alliances/{delegator_addr}/{validator_addr}/{denom}";
   }
 
+  // Query a delegation to an alliance by delegator addr, validator_addr and denom
+  rpc IBCAllianceDelegation(QueryIBCAllianceDelegationRequest) returns (QueryAllianceDelegationResponse) {
+    option (google.api.http).get = "/terra/alliances/{delegator_addr}/{validator_addr}/ibc/{hash}";
+  }
+
   // Query for rewards by delegator addr, validator_addr and denom
   rpc AllianceDelegationRewards(QueryAllianceDelegationRewardsRequest) returns (QueryAllianceDelegationRewardsResponse) {
-    option (google.api.http).get = "/terra/alliances/{delegator_addr}/{validator_addr}/{denom}";
+    option (google.api.http).get = "/terra/alliances/rewards/{delegator_addr}/{validator_addr}/{denom}";
+  }
+  // Query for rewards by delegator addr, validator_addr and denom
+  rpc IBCAllianceDelegationRewards(QueryIBCAllianceDelegationRewardsRequest) returns (QueryAllianceDelegationRewardsResponse) {
+    option (google.api.http).get = "/terra/alliances/rewards/{delegator_addr}/{validator_addr}/ibc/{hash}";
   }
 }
 
@@ -71,6 +85,10 @@ message QueryAllianceRequest {
 
 message QueryAllianceResponse {
   AllianceAsset alliance = 1;
+}
+
+message QueryIBCAllianceRequest {
+  string hash = 1;
 }
 
 // AlliancesDelegation
@@ -104,7 +122,17 @@ message QueryAllianceDelegationRequest {
 
   string delegator_addr  = 1;
   string validator_addr  = 2;
-  string denom              = 3;
+  string denom           = 3;
+  cosmos.base.query.v1beta1.PageRequest pagination = 4;
+}
+
+message QueryIBCAllianceDelegationRequest {
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  string delegator_addr  = 1;
+  string validator_addr  = 2;
+  string hash            = 3;
   cosmos.base.query.v1beta1.PageRequest pagination = 4;
 }
 
@@ -119,7 +147,17 @@ message QueryAllianceDelegationRewardsRequest {
 
   string delegator_addr  = 1;
   string validator_addr  = 2;
-  string denom              = 3;
+  string denom           = 3;
+  cosmos.base.query.v1beta1.PageRequest pagination = 4;
+}
+
+message QueryIBCAllianceDelegationRewardsRequest {
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  string delegator_addr  = 1;
+  string validator_addr  = 2;
+  string hash            = 3;
   cosmos.base.query.v1beta1.PageRequest pagination = 4;
 }
 

--- a/x/alliance/keeper/grpc_query.go
+++ b/x/alliance/keeper/grpc_query.go
@@ -92,6 +92,13 @@ func (k QueryServer) Alliance(c context.Context, req *types.QueryAllianceRequest
 	}, nil
 }
 
+func (k QueryServer) IBCAlliance(c context.Context, request *types.QueryIBCAllianceRequest) (*types.QueryAllianceResponse, error) {
+	req := types.QueryAllianceRequest{
+		Denom: "ibc/" + request.Hash,
+	}
+	return k.Alliance(c, &req)
+}
+
 func (k QueryServer) AllianceDelegationRewards(context context.Context, request *types.QueryAllianceDelegationRewardsRequest) (*types.QueryAllianceDelegationRewardsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(context)
 	delAddr, err := sdk.AccAddressFromBech32(request.DelegatorAddr)
@@ -124,6 +131,17 @@ func (k QueryServer) AllianceDelegationRewards(context context.Context, request 
 	return &types.QueryAllianceDelegationRewardsResponse{
 		Rewards: rewards,
 	}, nil
+}
+
+func (k QueryServer) IBCAllianceDelegationRewards(context context.Context, request *types.QueryIBCAllianceDelegationRewardsRequest) (*types.QueryAllianceDelegationRewardsResponse, error) {
+	req := types.QueryAllianceDelegationRewardsRequest{
+		DelegatorAddr: request.DelegatorAddr,
+		ValidatorAddr: request.ValidatorAddr,
+		Denom:         "ibc/" + request.Hash,
+		Pagination:    request.Pagination,
+	}
+
+	return k.AllianceDelegationRewards(context, &req)
 }
 
 func (k QueryServer) AlliancesDelegation(c context.Context, req *types.QueryAlliancesDelegationsRequest) (*types.QueryAlliancesDelegationsResponse, error) {
@@ -294,6 +312,15 @@ func (k QueryServer) AllianceDelegation(c context.Context, req *types.QueryAllia
 	}, nil
 }
 
+func (k QueryServer) IBCAllianceDelegation(c context.Context, request *types.QueryIBCAllianceDelegationRequest) (*types.QueryAllianceDelegationResponse, error) {
+	req := types.QueryAllianceDelegationRequest{
+		DelegatorAddr: request.DelegatorAddr,
+		ValidatorAddr: request.ValidatorAddr,
+		Denom:         "ibc/" + request.Hash,
+		Pagination:    request.Pagination,
+	}
+	return k.AllianceDelegation(c, &req)
+}
 func NewQueryServerImpl(keeper Keeper) types.QueryServer {
 	return &QueryServer{Keeper: keeper}
 }

--- a/x/alliance/keeper/grpc_query_test.go
+++ b/x/alliance/keeper/grpc_query_test.go
@@ -116,6 +116,42 @@ func TestQueryAnUniqueAlliance(t *testing.T) {
 	}, alliances)
 }
 
+func TestQueryAnUniqueIBCAlliance(t *testing.T) {
+	// GIVEN: THE BLOCKCHAIN WITH ALLIANCES ON GENESIS
+	app, ctx := createTestContext(t)
+	startTime := time.Now()
+	ctx = ctx.WithBlockTime(startTime).WithBlockHeight(1)
+	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
+		Params: types.DefaultParams(),
+		Assets: []types.AllianceAsset{
+			{
+				Denom:        "ibc/" + ALLIANCE_2_TOKEN_DENOM,
+				RewardWeight: sdk.NewDec(10),
+				TakeRate:     sdk.MustNewDecFromStr("0.14159265359"),
+				TotalTokens:  sdk.ZeroInt(),
+			},
+		},
+	})
+	queryServer := keeper.NewQueryServerImpl(app.AllianceKeeper)
+
+	// WHEN: QUERYING THE ALLIANCES LIST
+	alliances, err := queryServer.IBCAlliance(ctx, &types.QueryIBCAllianceRequest{
+		Hash: "alliance2",
+	})
+
+	// THEN: VALIDATE THAT BOTH ALLIANCES HAVE THE CORRECT MODEL WHEN QUERYING
+	require.Nil(t, err)
+	require.Equal(t, &types.QueryAllianceResponse{
+		Alliance: &types.AllianceAsset{
+			Denom:                "ibc/alliance2",
+			RewardWeight:         sdk.NewDec(10),
+			TakeRate:             sdk.MustNewDecFromStr("0.14159265359"),
+			TotalTokens:          sdk.ZeroInt(),
+			TotalValidatorShares: sdk.NewDec(0),
+		},
+	}, alliances)
+}
+
 func TestQueryAllianceNotFound(t *testing.T) {
 	// GIVEN: THE BLOCKCHAIN
 	app, ctx := createTestContext(t)


### PR DESCRIPTION
This pull request fixes the following issues:

- when querying an asset with the prefix `ibc/` it used to fail with the error "decoding bech32 failed: invalid bech32 string length 3", that happens because the slash is encoded. To prevent that issue from happening three more endpoints have been added "/terra/alliances/ibc/{hash}", "/terra/alliances/{delegator_addr}/{validator_addr}/ibc/{hash}" and "/terra/alliances/rewards/{delegator_addr}/{validator_addr}/ibc/{hash}", that does the same as their counterpart but avoid the encoding issue from happening.

- The second issue is related to the endpoint **GET:/terra/alliances/{delegator_addr}/{validator_addr}/{denoms}** because it was overlapping. To solve this issue there is a new endpoint with the following path **GET:/terra/alliances/rewards/{delegator_addr}/{validator_addr}/{denoms}** dedicated specifically to checking the rewards.