### PR TITLE
feat: take rate does not result in zero tokens

### DIFF
--- a/x/alliance/keeper/asset_test.go
+++ b/x/alliance/keeper/asset_test.go
@@ -857,3 +857,50 @@ func TestClaimTakeRate(t *testing.T) {
 		rewards.AmountOf(ALLIANCE_TOKEN_DENOM).Add(community.AmountOf(ALLIANCE_TOKEN_DENOM)),
 	)
 }
+
+func TestClaimTakeRateToZero(t *testing.T) {
+	app, ctx := createTestContext(t)
+	startTime := time.Now().UTC()
+	ctx = ctx.WithBlockTime(startTime)
+	ctx = ctx.WithBlockHeight(1)
+	takeRateInterval := time.Minute * 5
+	asset := types.NewAllianceAsset(ALLIANCE_TOKEN_DENOM, sdk.NewDec(2), sdk.MustNewDecFromStr("0.8"), startTime)
+	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
+		Params: types.Params{
+			RewardDelayTime:       time.Minute * 60,
+			TakeRateClaimInterval: takeRateInterval,
+			LastTakeRateClaimTime: startTime,
+		},
+		Assets: []types.AllianceAsset{
+			asset,
+		},
+	})
+
+	// Accounts
+	delegations := app.StakingKeeper.GetAllDelegations(ctx)
+	valAddr1, err := sdk.ValAddressFromBech32(delegations[0].ValidatorAddress)
+	require.NoError(t, err)
+	val1, err := app.AllianceKeeper.GetAllianceValidator(ctx, valAddr1)
+	require.NoError(t, err)
+	addrs := test_helpers.AddTestAddrsIncremental(app, ctx, 1, sdk.NewCoins(
+		sdk.NewCoin(ALLIANCE_TOKEN_DENOM, sdk.NewInt(1000_000_000)),
+	))
+	user1 := addrs[0]
+
+	app.AllianceKeeper.Delegate(ctx, user1, val1, sdk.NewCoin(ALLIANCE_TOKEN_DENOM, sdk.NewInt(1000_000_000)))
+	assets := app.AllianceKeeper.GetAllAssets(ctx)
+	err = app.AllianceKeeper.RebalanceBondTokenWeights(ctx, assets)
+	require.NoError(t, err)
+
+	timePassed := time.Minute * 5
+	// Advance block time
+	for i := 0; i < 1000; i++ {
+		ctx = ctx.WithBlockTime(ctx.BlockTime().Add(timePassed))
+		ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+		_, err = app.AllianceKeeper.DeductAssetsHook(ctx, assets)
+		require.NoError(t, err)
+	}
+
+	asset, _ = app.AllianceKeeper.GetAssetByDenom(ctx, ALLIANCE_TOKEN_DENOM)
+	require.True(t, asset.TotalTokens.GTE(sdk.OneInt()))
+}


### PR DESCRIPTION
This prevents take rate from being deducted to less than one token. 

When an asset's total tokens reach 0, delegating more to the asset would throw a division by zero error. This is due to the fact that the new delegators own all the new deposits and the old delegators own none. To represent this, the system needs to issue infinite shares to the new delegators.