### PR TITLE
fix: div by zero when take rate is applied

### DIFF
--- a/x/alliance/e2e/delegate_undelegate_test.go
+++ b/x/alliance/e2e/delegate_undelegate_test.go
@@ -1,0 +1,63 @@
+package e2e
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/rand"
+	"github.com/terra-money/alliance/x/alliance/types"
+	"testing"
+	"time"
+)
+
+// TestDelegateAndUndelegate
+// This test makes sure that full undelegation after some take rate has been
+// applied will not cause a division by zero error.
+func TestDelegateThenTakeRateThenUndelegate(t *testing.T) {
+	random := rand.NewRand()
+	app, ctx, vals, dels := setupApp(t, random, 5, 2, sdk.NewCoins(sdk.NewCoin("test", sdk.NewInt(1000000000000000000))))
+	err := app.AllianceKeeper.CreateAlliance(ctx, &types.MsgCreateAllianceProposal{
+		Title:                "",
+		Description:          "",
+		Denom:                "test",
+		RewardWeight:         sdk.MustNewDecFromStr("0.03"),
+		TakeRate:             sdk.MustNewDecFromStr("0.02"),
+		RewardChangeRate:     sdk.MustNewDecFromStr("0.01"),
+		RewardChangeInterval: time.Second * 60,
+	})
+	require.NoError(t, err)
+
+	val0, err := app.AllianceKeeper.GetAllianceValidator(ctx, vals[0])
+	require.NoError(t, err)
+
+	_, err = app.AllianceKeeper.Delegate(ctx, dels[0], val0, sdk.NewCoin("test", sdk.NewInt(100033333333333333)))
+	require.NoError(t, err)
+
+	val0, err = app.AllianceKeeper.GetAllianceValidator(ctx, vals[0])
+	require.Equal(t, sdk.NewDec(100033333333333333), sdk.DecCoins(val0.TotalDelegatorShares).AmountOf("test"))
+
+	lastClaim := ctx.BlockTime()
+	ctx = ctx.WithBlockTime(ctx.BlockTime().Add(time.Hour))
+	assets := app.AllianceKeeper.GetAllAssets(ctx)
+	_, err = app.AllianceKeeper.DeductAssetsWithTakeRate(ctx, lastClaim, assets)
+	require.NoError(t, err)
+
+	asset, found := app.AllianceKeeper.GetAssetByDenom(ctx, "test")
+
+	del0, found := app.AllianceKeeper.GetDelegation(ctx, dels[0], val0, "test")
+	require.True(t, found)
+	tokens := types.GetDelegationTokens(del0, val0, asset)
+	_, err = app.AllianceKeeper.Undelegate(ctx, dels[0], val0, tokens)
+	require.NoError(t, err)
+
+	_, found = app.AllianceKeeper.GetDelegation(ctx, dels[0], val0, "test")
+	require.False(t, found)
+
+	val0, err = app.AllianceKeeper.GetAllianceValidator(ctx, vals[0])
+	require.Equal(t, sdk.ZeroDec(), sdk.DecCoins(val0.ValidatorShares).AmountOf("test"))
+
+	tokens = types.GetDelegationTokens(del0, val0, asset)
+	asset, found = app.AllianceKeeper.GetAssetByDenom(ctx, "test")
+
+	_, err = app.AllianceKeeper.Delegate(ctx, dels[0], val0, sdk.NewCoin("test", sdk.NewInt(33333)))
+	require.NoError(t, err)
+}

--- a/x/alliance/e2e/test_helper.go
+++ b/x/alliance/e2e/test_helper.go
@@ -1,0 +1,42 @@
+package e2e
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/staking/teststaking"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/tendermint/tendermint/libs/rand"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	test_helpers "github.com/terra-money/alliance/app"
+	"testing"
+	"time"
+)
+
+func setupApp(t *testing.T, r *rand.Rand, numValidators int, numDelegators int, initBalance sdk.Coins) (app *test_helpers.App, ctx sdk.Context, valAddrs []sdk.ValAddress, delAddrs []sdk.AccAddress) {
+	app = test_helpers.Setup(t, false)
+	ctx = app.BaseApp.NewContext(false, tmproto.Header{})
+	startTime := time.Now()
+	ctx = ctx.WithBlockTime(startTime)
+
+	// Accounts
+	valAccAddrs := test_helpers.AddTestAddrsIncremental(app, ctx, numValidators, sdk.NewCoins())
+	pks := test_helpers.CreateTestPubKeys(numValidators)
+
+	for i := 0; i < numValidators; i += 1 {
+		valAddr := sdk.ValAddress(valAccAddrs[i])
+		valAddrs = append(valAddrs, valAddr)
+		_val := teststaking.NewValidator(t, valAddr, pks[i])
+		_val.Commission = stakingtypes.Commission{
+			CommissionRates: stakingtypes.CommissionRates{
+				Rate:          sdk.NewDec(0),
+				MaxRate:       sdk.NewDec(0),
+				MaxChangeRate: sdk.NewDec(0),
+			},
+			UpdateTime: time.Now(),
+		}
+		_val.Status = stakingtypes.Bonded
+		test_helpers.RegisterNewValidator(t, app, ctx, _val)
+	}
+
+	delAddrs = test_helpers.AddTestAddrsIncremental(app, ctx, numDelegators, initBalance)
+	return
+}


### PR DESCRIPTION
Fixes #68 

Introduce a method to reset the state of validators and asset when all tokens have been undelegated