### PR TITLE
use go 1.19

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,37 @@
+name: docker
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          file: scripts/containers/Dockerfile
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: user/app:latest

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ By design, x/alliance use the following CosmosSDK modules to implement interchai
 
 
 # Development environment
-This project uses [Go v1.18](https://go.dev/dl/) and was bootstrapped with [Ignite CLI v0.25.1](https://docs.ignite.com/). However, for ease of upgrade, ignite has been removed in favor of manual workflows.
+This project uses [Go v1.19](https://go.dev/dl/) and was bootstrapped with [Ignite CLI v0.25.1](https://docs.ignite.com/). However, for ease of upgrade, ignite has been removed in favor of manual workflows.
 
 To run the local development environment use:
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terra-money/alliance
 
-go 1.18
+go 1.19
 
 require (
 	cosmossdk.io/errors v1.0.0-beta.7

--- a/scripts/containers/Dockerfile
+++ b/scripts/containers/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.7-bullseye AS build
+FROM golang:1.19-bullseye AS build
 
 RUN apt update && apt install jq build-essential -y
 


### PR DESCRIPTION
Go 1.18 and 1.19 can cause things to differ, up to and including app hashes, though mainly state sync snapshots, due to a change in gzip in golang.

Using go 1.19 everywhere is safest, because you can build a chain that specifies go 1.18 with 1.19, but you cannot build a chain that specifies 1.19 with 1.18
