### PR TITLE
fix: bug fixes due to rounding issues when dealing with small delegations

### DIFF
--- a/x/alliance/keeper/delegation.go
+++ b/x/alliance/keeper/delegation.go
@@ -190,7 +190,7 @@ func (k Keeper) Undelegate(ctx sdk.Context, delAddr sdk.AccAddress, validator ty
 	// When there are no more tokens recorded in the asset, clear all share records that might remain
 	// from rounding errors to prevent dust amounts from staying in the stores
 	if asset.TotalTokens.IsZero() {
-		k.ResetAssetAndValidators(ctx, asset) //nolint:errcheck
+		k.ResetAssetAndValidators(ctx, asset)
 	}
 
 	// Queue undelegation messages to distribute tokens after undelegation completes in the future

--- a/x/alliance/tests/benchmark/benchmark_test.go
+++ b/x/alliance/tests/benchmark/benchmark_test.go
@@ -212,7 +212,7 @@ func undelegateOperation(ctx sdk.Context, app *test_helpers.App, r *rand.Rand) {
 	if amountToUndelegate.IsZero() {
 		return
 	}
-	_, err := app.AllianceKeeper.Undelegate(ctx, delAddr, validator, sdk.NewCoin(asset.Denom, amountToUndelegate)) //nolint:errcheck
+	_, err := app.AllianceKeeper.Undelegate(ctx, delAddr, validator, sdk.NewCoin(asset.Denom, amountToUndelegate))
 	if err != nil {
 		panic(err)
 	}

--- a/x/alliance/tests/benchmark/benchmark_test.go
+++ b/x/alliance/tests/benchmark/benchmark_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	SEED               = 1
+	SEED               = int64(1)
 	NumOfBlocks        = 1000
 	BlocktimeInSeconds = 5
 	VoteRate           = 0.8
@@ -38,7 +38,7 @@ var (
 var createdDelegations = []types.Delegation{}
 
 func TestRunBenchmarks(t *testing.T) {
-	r := rand.New(rand.NewSource(1))
+	r := rand.New(rand.NewSource(SEED))
 	app, ctx, assets, vals, dels := benchmark.SetupApp(t, r, NumOfAssets, NumOfValidators, NumOfDelegators)
 	powerReduction := sdk.OneInt()
 	operations := make(map[string]int)
@@ -212,7 +212,10 @@ func undelegateOperation(ctx sdk.Context, app *test_helpers.App, r *rand.Rand) {
 	if amountToUndelegate.IsZero() {
 		return
 	}
-	app.AllianceKeeper.Undelegate(ctx, delAddr, validator, sdk.NewCoin(asset.Denom, amountToUndelegate)) //nolint:errcheck
+	_, err := app.AllianceKeeper.Undelegate(ctx, delAddr, validator, sdk.NewCoin(asset.Denom, amountToUndelegate)) //nolint:errcheck
+	if err != nil {
+		panic(err)
+	}
 }
 
 func claimRewardsOperation(ctx sdk.Context, app *test_helpers.App, r *rand.Rand) {

--- a/x/alliance/tests/e2e/delegate_undelegate_test.go
+++ b/x/alliance/tests/e2e/delegate_undelegate_test.go
@@ -1,9 +1,10 @@
 package e2e
 
 import (
-	"github.com/terra-money/alliance/x/alliance/keeper"
 	"testing"
 	"time"
+
+	"github.com/terra-money/alliance/x/alliance/keeper"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
@@ -237,4 +238,77 @@ func TestDelegateAndUndelegateWithSmallAmounts(t *testing.T) {
 	// Undelegate token with more than current amount still pass
 	_, err = app.AllianceKeeper.Undelegate(ctx, user1, val1, del.Balance)
 	require.NoError(t, err)
+}
+
+// This test replicates un-delegating slightly more (1 utoken more) than the balance of token
+// Due to truncation of shares, un-delegation's validation might allow more tokens to be removed than there exists in
+// the delegation.
+func TestNegativeCoin(t *testing.T) {
+	allianceAsset1 := "asset1"
+	allianceAsset2 := "asset2"
+
+	app, ctx, vals, dels := setupApp(t, 5, 2, sdk.NewCoins(
+		sdk.NewCoin(allianceAsset1, sdk.NewInt(1000000000000000000)),
+		sdk.NewCoin(allianceAsset2, sdk.NewInt(1000000000000000000)),
+	))
+	startTime := time.Now()
+	ctx = ctx.WithBlockTime(startTime).WithBlockHeight(1)
+	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
+		Params: types.DefaultParams(),
+		Assets: []types.AllianceAsset{
+			types.NewAllianceAsset(allianceAsset1, sdk.NewDec(2), sdk.NewDec(0), ctx.BlockTime()),
+			types.NewAllianceAsset(allianceAsset2, sdk.NewDec(10), sdk.MustNewDecFromStr("0.1"), ctx.BlockTime()),
+		},
+	})
+	queryServer := keeper.NewQueryServerImpl(app.AllianceKeeper)
+
+	// Set tax and rewards to be zero for easier calculation
+	distParams := app.DistrKeeper.GetParams(ctx)
+	distParams.CommunityTax = sdk.ZeroDec()
+	distParams.BaseProposerReward = sdk.ZeroDec()
+	distParams.BonusProposerReward = sdk.ZeroDec()
+	app.DistrKeeper.SetParams(ctx, distParams)
+
+	val1, err := app.AllianceKeeper.GetAllianceValidator(ctx, vals[0])
+	require.NoError(t, err)
+	val2, err := app.AllianceKeeper.GetAllianceValidator(ctx, vals[1])
+	require.NoError(t, err)
+
+	user1 := dels[0]
+	user2 := dels[1]
+
+	// Delegate token with non-zero take_rate
+	_, err = app.AllianceKeeper.Delegate(ctx, user1, val1, sdk.NewCoin(allianceAsset2, sdk.NewInt(5000)))
+	require.NoError(t, err)
+	_, err = app.AllianceKeeper.Delegate(ctx, user2, val2, sdk.NewCoin(allianceAsset2, sdk.NewInt(1000_000_000)))
+	require.NoError(t, err)
+
+	assets := app.AllianceKeeper.GetAllAssets(ctx)
+	err = app.AllianceKeeper.RebalanceBondTokenWeights(ctx, assets)
+	require.NoError(t, err)
+
+	// Check total bonded amount
+	// require.Equal(t, sdk.NewInt(11_000_000), app.StakingKeeper.TotalBondedTokens(ctx))
+
+	ctx = ctx.WithBlockTime(startTime.Add(time.Minute * 6)).WithBlockHeight(2)
+	// coins, err := app.AllianceKeeper.DeductAssetsHook(ctx, assets)
+	// require.NoError(t, err)
+	// require.False(t, coins.IsZero())
+
+	res, err := queryServer.AllianceDelegation(ctx, &types.QueryAllianceDelegationRequest{
+		DelegatorAddr: user1.String(),
+		ValidatorAddr: val1.GetOperator().String(),
+		Denom:         allianceAsset2,
+		Pagination:    nil,
+	})
+	require.NoError(t, err)
+	del := res.GetDelegation()
+	// require.True(t, del.GetBalance().Amount.LT(sdk.NewInt(1000_000_000)), "%s should be less than %s", del.GetBalance().Amount, sdk.NewInt(1000_000_000))
+	// Undelegate token with initial amount should fail
+	_, err = app.AllianceKeeper.Undelegate(ctx, user1, val1, sdk.NewCoin(allianceAsset2, sdk.NewInt(1000_000_000)))
+	require.Error(t, err)
+
+	// Undelegate token with more than current amount should fail
+	_, err = app.AllianceKeeper.Undelegate(ctx, user1, val1, sdk.NewCoin(allianceAsset2, del.Balance.Amount.AddRaw(1)))
+	require.Error(t, err)
 }

--- a/x/alliance/tests/e2e/delegate_undelegate_test.go
+++ b/x/alliance/tests/e2e/delegate_undelegate_test.go
@@ -172,3 +172,69 @@ func TestDelegatingASmallAmount(t *testing.T) {
 	del = res.GetDelegation()
 	require.True(t, del.Balance.Amount.IsZero())
 }
+
+// This test replicates this issue where there are large amounts of tokens delegated,
+// calculating token balances for a small delegation is rounded wrongly
+// E.g. When user delegated 200 tokens, there was an issue such that it showed 199 tokens instead
+func TestDelegateAndUndelegateWithSmallAmounts(t *testing.T) {
+	allianceAsset1 := "asset1"
+	allianceAsset2 := "asset2"
+
+	app, ctx, vals, dels := setupApp(t, 5, 2, sdk.NewCoins(
+		sdk.NewCoin(allianceAsset1, sdk.NewInt(2000_000_000_000_000_000)),
+		sdk.NewCoin(allianceAsset2, sdk.NewInt(2000_000_000_000_000_000)),
+	))
+	startTime := time.Now()
+	ctx = ctx.WithBlockTime(startTime).WithBlockHeight(1)
+	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
+		Params: types.DefaultParams(),
+		Assets: []types.AllianceAsset{
+			types.NewAllianceAsset(allianceAsset1, sdk.NewDec(2), sdk.NewDec(0), ctx.BlockTime()),
+			types.NewAllianceAsset(allianceAsset2, sdk.NewDec(10), sdk.MustNewDecFromStr("0.1"), ctx.BlockTime()),
+		},
+	})
+	queryServer := keeper.NewQueryServerImpl(app.AllianceKeeper)
+
+	// Set tax and rewards to be zero for easier calculation
+	distParams := app.DistrKeeper.GetParams(ctx)
+	distParams.CommunityTax = sdk.ZeroDec()
+	distParams.BaseProposerReward = sdk.ZeroDec()
+	distParams.BonusProposerReward = sdk.ZeroDec()
+	app.DistrKeeper.SetParams(ctx, distParams)
+
+	val1, err := app.AllianceKeeper.GetAllianceValidator(ctx, vals[0])
+	val2, err := app.AllianceKeeper.GetAllianceValidator(ctx, vals[1])
+
+	user1 := dels[0]
+	user2 := dels[1]
+
+	// Delegate token with non-zero take_rate
+	_, err = app.AllianceKeeper.Delegate(ctx, user1, val1, sdk.NewCoin(allianceAsset2, sdk.NewInt(200)))
+	require.NoError(t, err)
+	_, err = app.AllianceKeeper.Delegate(ctx, user2, val2, sdk.NewCoin(allianceAsset2, sdk.NewInt(1000_000_000_000_000_000)))
+	require.NoError(t, err)
+
+	assets := app.AllianceKeeper.GetAllAssets(ctx)
+	err = app.AllianceKeeper.RebalanceBondTokenWeights(ctx, assets)
+	require.NoError(t, err)
+
+	ctx = ctx.WithBlockTime(startTime.Add(time.Minute * 6)).WithBlockHeight(2)
+
+	res, err := queryServer.AllianceDelegation(ctx, &types.QueryAllianceDelegationRequest{
+		DelegatorAddr: user1.String(),
+		ValidatorAddr: val1.GetOperator().String(),
+		Denom:         allianceAsset2,
+		Pagination:    nil,
+	})
+	require.NoError(t, err)
+	del := res.GetDelegation()
+
+	// Undelegate token with initial amount should fail
+	_, err = app.AllianceKeeper.Undelegate(ctx, user1, val1, sdk.NewCoin(allianceAsset2, sdk.NewInt(1000_000_000_000_000_000)))
+	require.Error(t, err)
+	require.Equal(t, del.Balance.Amount, sdk.NewInt(200))
+
+	// Undelegate token with more than current amount still pass
+	_, err = app.AllianceKeeper.Undelegate(ctx, user1, val1, del.Balance)
+	require.NoError(t, err)
+}

--- a/x/alliance/tests/e2e/delegate_undelegate_test.go
+++ b/x/alliance/tests/e2e/delegate_undelegate_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"github.com/terra-money/alliance/x/alliance/keeper"
 	"testing"
 	"time"
 
@@ -60,4 +61,114 @@ func TestDelegateThenTakeRateThenUndelegate(t *testing.T) {
 
 	_, err = app.AllianceKeeper.Delegate(ctx, dels[0], val0, sdk.NewCoin("test", sdk.NewInt(33333)))
 	require.NoError(t, err)
+}
+
+// Tests delegating a small amount that triggers a re-balancing event that adds < 1 utoken to a validator.
+// Re-balancing event should ignore small delegations < 1 utoken since it rounds down to 0.
+func TestDelegatingASmallAmount(t *testing.T) {
+	allianceAsset1 := "asset1"
+	allianceAsset2 := "asset2"
+
+	app, ctx, vals, dels := setupApp(t, 5, 2, sdk.NewCoins(
+		sdk.NewCoin(allianceAsset1, sdk.NewInt(1000000000000000000)),
+		sdk.NewCoin(allianceAsset2, sdk.NewInt(1000000000000000000)),
+	))
+	startTime := time.Now()
+	ctx = ctx.WithBlockTime(startTime).WithBlockHeight(1)
+	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
+		Params: types.DefaultParams(),
+		Assets: []types.AllianceAsset{
+			types.NewAllianceAsset(allianceAsset1, sdk.NewDec(2), sdk.NewDec(0), ctx.BlockTime()),
+			types.NewAllianceAsset(allianceAsset2, sdk.NewDec(10), sdk.MustNewDecFromStr("0.1"), ctx.BlockTime()),
+		},
+	})
+	queryServer := keeper.NewQueryServerImpl(app.AllianceKeeper)
+
+	// Set tax and rewards to be zero for easier calculation
+	distParams := app.DistrKeeper.GetParams(ctx)
+	distParams.CommunityTax = sdk.ZeroDec()
+	distParams.BaseProposerReward = sdk.ZeroDec()
+	distParams.BonusProposerReward = sdk.ZeroDec()
+	app.DistrKeeper.SetParams(ctx, distParams)
+
+	user1 := dels[0]
+	user2 := dels[1]
+
+	val1, err := app.AllianceKeeper.GetAllianceValidator(ctx, vals[0])
+	val2, err := app.AllianceKeeper.GetAllianceValidator(ctx, vals[1])
+
+	// Delegate token with non-zero take_rate
+	_, err = app.AllianceKeeper.Delegate(ctx, user1, val1, sdk.NewCoin(allianceAsset2, sdk.NewInt(100)))
+	require.NoError(t, err)
+	_, err = app.AllianceKeeper.Delegate(ctx, user2, val2, sdk.NewCoin(allianceAsset2, sdk.NewInt(1000_000_000)))
+	require.NoError(t, err)
+
+	assets := app.AllianceKeeper.GetAllAssets(ctx)
+	err = app.AllianceKeeper.RebalanceBondTokenWeights(ctx, assets)
+	require.NoError(t, err)
+
+	coins, err := app.AllianceKeeper.DeductAssetsHook(ctx, assets)
+	require.NoError(t, err)
+
+	res, err := queryServer.AllianceDelegation(ctx, &types.QueryAllianceDelegationRequest{
+		DelegatorAddr: user1.String(),
+		ValidatorAddr: val1.GetOperator().String(),
+		Denom:         allianceAsset2,
+		Pagination:    nil,
+	})
+	require.NoError(t, err)
+
+	del := res.GetDelegation()
+	_, err = app.AllianceKeeper.Undelegate(ctx, user1, val1, sdk.NewCoin(allianceAsset2, sdk.NewInt(1000_000_000)))
+	require.Error(t, err)
+
+	// Undelegate token with current amount should pass
+	_, err = app.AllianceKeeper.Undelegate(ctx, user1, val1, del.Balance)
+	require.NoError(t, err)
+
+	// User should have everything withdrawn
+	_, found := app.AllianceKeeper.GetDelegation(ctx, user1, val1, allianceAsset2)
+	require.False(t, found)
+
+	// Delegate again
+	_, err = app.AllianceKeeper.Delegate(ctx, user1, val1, sdk.NewCoin(allianceAsset2, sdk.NewInt(500_000_000)))
+	require.NoError(t, err)
+
+	ctx = ctx.WithBlockTime(ctx.BlockTime().Add(time.Minute * 1)).WithBlockHeight(2)
+
+	_, err = app.AllianceKeeper.Delegate(ctx, user1, val1, sdk.NewCoin(allianceAsset2, sdk.NewInt(400_000_000)))
+	require.NoError(t, err)
+
+	ctx = ctx.WithBlockTime(ctx.BlockTime().Add(time.Minute * 5)).WithBlockHeight(3)
+	coins, err = app.AllianceKeeper.DeductAssetsHook(ctx, assets)
+	require.NoError(t, err)
+	require.False(t, coins.IsZero())
+
+	res, err = queryServer.AllianceDelegation(ctx, &types.QueryAllianceDelegationRequest{
+		DelegatorAddr: user1.String(),
+		ValidatorAddr: val1.GetOperator().String(),
+		Denom:         allianceAsset2,
+		Pagination:    nil,
+	})
+	require.NoError(t, err)
+	del = res.GetDelegation()
+	require.True(t, del.GetBalance().Amount.LT(sdk.NewInt(900_000_000)), "%s should be less than %s", del.GetBalance().Amount, sdk.NewInt(1000_000_000))
+
+	// Undelegate token with current amount should pass
+	_, err = app.AllianceKeeper.Undelegate(ctx, user1, val1, sdk.NewCoin(allianceAsset2, del.Balance.Amount))
+	require.NoError(t, err)
+
+	// User should have everything withdrawn
+	_, found = app.AllianceKeeper.GetDelegation(ctx, user1, val1, allianceAsset2)
+	require.False(t, found)
+
+	res, err = queryServer.AllianceDelegation(ctx, &types.QueryAllianceDelegationRequest{
+		DelegatorAddr: user1.String(),
+		ValidatorAddr: val1.GetOperator().String(),
+		Denom:         allianceAsset2,
+		Pagination:    nil,
+	})
+	require.NoError(t, err)
+	del = res.GetDelegation()
+	require.True(t, del.Balance.Amount.IsZero())
 }

--- a/x/alliance/types/asset.go
+++ b/x/alliance/types/asset.go
@@ -46,6 +46,17 @@ func GetDelegationTokens(del Delegation, val AllianceValidator, asset AllianceAs
 	return sdk.NewCoin(asset.Denom, delTokens.TruncateInt())
 }
 
+func GetDelegationTokensWithShares(delegatorShares sdk.Dec, val AllianceValidator, asset AllianceAsset) sdk.Coin {
+	valTokens := val.TotalDecTokensWithAsset(asset)
+	totalDelegationShares := val.TotalDelegationSharesWithDenom(asset.Denom)
+	delTokens := ConvertNewShareToDecToken(valTokens, totalDelegationShares, delegatorShares)
+
+	// We add a small epsilon before rounding down to make sure cases like
+	// 9.999999 get round to 10
+	delTokens = delTokens.Add(sdk.NewDecWithPrec(1, 6))
+	return sdk.NewCoin(asset.Denom, delTokens.TruncateInt())
+}
+
 func GetDelegationSharesFromTokens(val AllianceValidator, asset AllianceAsset, token cosmosmath.Int) sdk.Dec {
 	valTokens := val.TotalTokensWithAsset(asset)
 	totalDelegationShares := val.TotalDelegationSharesWithDenom(asset.Denom)
@@ -53,10 +64,6 @@ func GetDelegationSharesFromTokens(val AllianceValidator, asset AllianceAsset, t
 		return sdk.NewDecFromInt(token)
 	}
 	return ConvertNewTokenToShares(valTokens, totalDelegationShares, token)
-}
-
-func GetValidatorShares(asset AllianceAsset, token cosmosmath.Int) sdk.Dec {
-	return ConvertNewTokenToShares(sdk.NewDecFromInt(asset.TotalTokens), asset.TotalValidatorShares, token)
 }
 
 func (a AllianceAsset) HasPositiveDecay() bool {

--- a/x/alliance/types/asset.go
+++ b/x/alliance/types/asset.go
@@ -39,6 +39,10 @@ func GetDelegationTokens(del Delegation, val AllianceValidator, asset AllianceAs
 	valTokens := val.TotalDecTokensWithAsset(asset)
 	totalDelegationShares := val.TotalDelegationSharesWithDenom(asset.Denom)
 	delTokens := ConvertNewShareToDecToken(valTokens, totalDelegationShares, del.Shares)
+
+	// We add a small epsilon before rounding down to make sure cases like
+	// 9.999999 get round to 10
+	delTokens = delTokens.Add(sdk.NewDecWithPrec(1, 6))
 	return sdk.NewCoin(asset.Denom, delTokens.TruncateInt())
 }
 

--- a/x/alliance/types/errors.go
+++ b/x/alliance/types/errors.go
@@ -1,6 +1,8 @@
 package types
 
-import sdkerrors "cosmossdk.io/errors"
+import (
+	sdkerrors "cosmossdk.io/errors"
+)
 
 var (
 	ErrInvalidGenesisState = sdkerrors.Register(ModuleName, 0, "invalid genesis state")
@@ -8,7 +10,8 @@ var (
 	ErrEmptyValidatorAddr = sdkerrors.Register(ModuleName, 10, "empty validator address")
 	ErrValidatorNotFound  = sdkerrors.Register(ModuleName, 11, "validator not found")
 
-	ErrZeroDelegations = sdkerrors.Register(ModuleName, 20, "there are no delegations yet")
+	ErrZeroDelegations    = sdkerrors.Register(ModuleName, 20, "there are no delegations yet")
+	ErrInsufficientTokens = sdkerrors.Register(ModuleName, 21, "insufficient tokens")
 
 	ErrUnknownAsset = sdkerrors.Register(ModuleName, 30, "alliance asset is not whitelisted")
 )

--- a/x/alliance/types/validator.go
+++ b/x/alliance/types/validator.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	cosmosmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
@@ -72,4 +73,8 @@ func (v AllianceValidator) TotalTokensWithAsset(asset AllianceAsset) sdk.Dec {
 func (v AllianceValidator) TotalDecTokensWithAsset(asset AllianceAsset) sdk.Dec {
 	shares := v.ValidatorSharesWithDenom(asset.Denom)
 	return ConvertNewShareToDecToken(sdk.NewDecFromInt(asset.TotalTokens), asset.TotalValidatorShares, shares)
+}
+
+func GetValidatorShares(asset AllianceAsset, token cosmosmath.Int) sdk.Dec {
+	return ConvertNewTokenToShares(sdk.NewDecFromInt(asset.TotalTokens), asset.TotalValidatorShares, token)
 }


### PR DESCRIPTION
Added more checks and rounding handling when dealing with small delegations (< 1000 utokens). 
1. [fix: rebalance voting power breaks when handling small delegations](https://github.com/terra-money/alliance/pull/79/commits/4744436b04a55c93611b4e0d4449af24a03fb12a)
2. [fix: rounding error when querying delegated tokens](https://github.com/terra-money/alliance/pull/79/commits/fcb8d0fef33879a162abbb5bf94f77178fed6542)
3. [fix: panic when un-delegating more tokens than balance](https://github.com/terra-money/alliance/pull/79/commits/771349adb0a05290b758796f750644834bf82026)
4. [fix: panic when re-delegating more tokens than balance](https://github.com/terra-money/alliance/pull/79/commits/410167ac613125a87313a84dfec37b0680be21be)