### PR TITLE
Reorder events

### DIFF
--- a/x/alliance/keeper/delegation.go
+++ b/x/alliance/keeper/delegation.go
@@ -53,6 +53,15 @@ func (k Keeper) Delegate(ctx sdk.Context, delAddr sdk.AccAddress, validator type
 		true,
 	)
 	k.QueueAssetRebalanceEvent(ctx)
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeDelegate,
+			sdk.NewAttribute(types.AttributeKeyValidator, validator.OperatorAddress),
+			sdk.NewAttribute(sdk.AttributeKeyAmount, coin.Amount.String()),
+			sdk.NewAttribute(types.AttributeKeyNewShares, newValidatorShares.String()),
+		),
+	})
 	return &newValidatorShares, nil
 }
 
@@ -132,6 +141,16 @@ func (k Keeper) Redelegate(ctx sdk.Context, delAddr sdk.AccAddress, srcVal types
 
 	k.QueueAssetRebalanceEvent(ctx)
 
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeRedelegate,
+			sdk.NewAttribute(types.AttributeKeySrcValidator, srcVal.OperatorAddress),
+			sdk.NewAttribute(types.AttributeKeyDstValidator, dstVal.OperatorAddress),
+			sdk.NewAttribute(sdk.AttributeKeyAmount, coin.Amount.String()),
+			sdk.NewAttribute(types.AttributeKeyCompletionTime, completionTime.Format(time.RFC3339)),
+		),
+	})
+
 	return &completionTime, nil
 }
 
@@ -196,6 +215,15 @@ func (k Keeper) Undelegate(ctx sdk.Context, delAddr sdk.AccAddress, validator ty
 	// Queue undelegation messages to distribute tokens after undelegation completes in the future
 	completionTime := k.queueUndelegation(ctx, delAddr, validator.GetOperator(), coin)
 	k.QueueAssetRebalanceEvent(ctx)
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeUndelegate,
+			sdk.NewAttribute(types.AttributeKeyValidator, validator.OperatorAddress),
+			sdk.NewAttribute(sdk.AttributeKeyAmount, coin.Amount.String()),
+			sdk.NewAttribute(types.AttributeKeyCompletionTime, completionTime.Format(time.RFC3339)),
+		),
+	})
 	return &completionTime, nil
 }
 

--- a/x/alliance/keeper/msg_server.go
+++ b/x/alliance/keeper/msg_server.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"time"
 
 	"github.com/terra-money/alliance/x/alliance/types"
 
@@ -36,19 +35,10 @@ func (m MsgServer) Delegate(ctx context.Context, msg *types.MsgDelegate) (*types
 		return nil, err
 	}
 
-	newShares, err := m.Keeper.Delegate(sdkCtx, delAddr, validator, msg.Amount)
+	_, err = m.Keeper.Delegate(sdkCtx, delAddr, validator, msg.Amount)
 	if err != nil {
 		return nil, err
 	}
-
-	sdkCtx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeDelegate,
-			sdk.NewAttribute(types.AttributeKeyValidator, msg.ValidatorAddress),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),
-			sdk.NewAttribute(types.AttributeKeyNewShares, newShares.String()),
-		),
-	})
 
 	return &types.MsgDelegateResponse{}, nil
 }
@@ -84,20 +74,11 @@ func (m MsgServer) Redelegate(ctx context.Context, msg *types.MsgRedelegate) (*t
 		return nil, err
 	}
 
-	completionTime, err := m.Keeper.Redelegate(sdkCtx, delAddr, srcValidator, dstValidator, msg.Amount)
+	_, err = m.Keeper.Redelegate(sdkCtx, delAddr, srcValidator, dstValidator, msg.Amount)
 	if err != nil {
 		return nil, err
 	}
 
-	sdkCtx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeRedelegate,
-			sdk.NewAttribute(types.AttributeKeySrcValidator, msg.ValidatorSrcAddress),
-			sdk.NewAttribute(types.AttributeKeyDstValidator, msg.ValidatorDstAddress),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),
-			sdk.NewAttribute(types.AttributeKeyCompletionTime, completionTime.Format(time.RFC3339)),
-		),
-	})
 	return &types.MsgRedelegateResponse{}, nil
 }
 
@@ -122,19 +103,11 @@ func (m MsgServer) Undelegate(ctx context.Context, msg *types.MsgUndelegate) (*t
 		return nil, err
 	}
 
-	completionTime, err := m.Keeper.Undelegate(sdkCtx, delAddr, validator, msg.Amount)
+	_, err = m.Keeper.Undelegate(sdkCtx, delAddr, validator, msg.Amount)
 	if err != nil {
 		return nil, err
 	}
 
-	sdkCtx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeUndelegate,
-			sdk.NewAttribute(types.AttributeKeyValidator, msg.ValidatorAddress),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),
-			sdk.NewAttribute(types.AttributeKeyCompletionTime, completionTime.Format(time.RFC3339)),
-		),
-	})
 	return &types.MsgUndelegateResponse{}, nil
 }
 
@@ -159,15 +132,8 @@ func (m MsgServer) ClaimDelegationRewards(ctx context.Context, msg *types.MsgCla
 		return nil, err
 	}
 
-	coins, err := m.Keeper.ClaimDelegationRewards(sdkCtx, delAddr, validator, msg.Denom)
+	_, err = m.Keeper.ClaimDelegationRewards(sdkCtx, delAddr, validator, msg.Denom)
 
-	sdkCtx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeClaimDelegationRewards,
-			sdk.NewAttribute(types.AttributeKeyValidator, msg.ValidatorAddress),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, coins.String()),
-		),
-	})
 	return &types.MsgClaimDelegationRewardsResponse{}, err
 }
 

--- a/x/alliance/keeper/reward.go
+++ b/x/alliance/keeper/reward.go
@@ -63,6 +63,13 @@ func (k Keeper) ClaimDelegationRewards(ctx sdk.Context, delAddr sdk.AccAddress, 
 		return nil, err
 	}
 
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeClaimDelegationRewards,
+			sdk.NewAttribute(types.AttributeKeyValidator, val.OperatorAddress),
+			sdk.NewAttribute(sdk.AttributeKeyAmount, coins.String()),
+		),
+	})
 	return coins, nil
 }
 

--- a/x/alliance/types/events.go
+++ b/x/alliance/types/events.go
@@ -1,10 +1,10 @@
 package types
 
 const (
-	EventTypeDelegate               = "delegate"
-	EventTypeUndelegate             = "undelegate"
-	EventTypeRedelegate             = "redelegate"
-	EventTypeClaimDelegationRewards = "claim_delegation_rewards"
+	EventTypeDelegate               = "alliance_delegate"
+	EventTypeUndelegate             = "alliance_undelegate"
+	EventTypeRedelegate             = "alliance_redelegate"
+	EventTypeClaimDelegationRewards = "alliance_claim_delegation_rewards"
 
 	AttributeKeyValidator      = "validator"
 	AttributeKeySrcValidator   = "source_validator"


### PR DESCRIPTION
Alliance module events moved from the `MsgServer` to its respective keeper method to ensure that data indexing is accurate when someone reads the block logs. Also the event names have been prefixed with alliance that way we avoid confusions with x/staking module events.