### PR TITLE
feat: delete dust delegations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,10 +87,16 @@ install: go.sum
 ###                                Test                                     ###
 ###############################################################################
 
-test: test-unit
+test: test-unit test-e2e
 
 test-unit:
-	@VERSION=$(VERSION) go test -v -mod=readonly -tags='ledger test_ledger_mock' github.com/terra-money/alliance/x/alliance/keeper/tests github.com/terra-money/alliance/x/alliance/types/tests
+	@VERSION=$(VERSION) go test -mod=readonly -tags='ledger test_ledger_mock' github.com/terra-money/alliance/x/alliance/keeper/tests github.com/terra-money/alliance/x/alliance/types/tests
+
+test-e2e:
+	@VERSION=$(VERSION) go test -mod=readonly -tags='ledger test_ledger_mock' github.com/terra-money/alliance/x/alliance/tests/e2e
+
+test-benchmark:
+	@VERSION=$(VERSION) go test -v -mod=readonly -tags='ledger test_ledger_mock' github.com/terra-money/alliance/x/alliance/tests/benchmark
 
 ###############################################################################
 ###                                Linting                                  ###

--- a/x/alliance/tests/e2e/delegate_undelegate_test.go
+++ b/x/alliance/tests/e2e/delegate_undelegate_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/terra-money/alliance/x/alliance"
+
 	"github.com/terra-money/alliance/x/alliance/keeper"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -67,6 +69,66 @@ func TestDelegateThenTakeRateThenUndelegate(t *testing.T) {
 
 	_, err = app.AllianceKeeper.Delegate(ctx, dels[0], val0, sdk.NewCoin("test", sdk.NewInt(33333)))
 	require.NoError(t, err)
+
+	_, stop := alliance.RunAllInvariants(ctx, app.AllianceKeeper)
+	require.False(t, stop)
+}
+
+// TestDelegateThenTakeRateThenRedelegate
+// This test makes sure that full redelegation after some take rate has been
+// applied will not cause a division by zero error. Also ensure that dust delegations are not kept around
+func TestDelegateThenTakeRateThenRedelegate(t *testing.T) {
+	app, ctx, vals, dels := setupApp(t, 5, 2, sdk.NewCoins(sdk.NewCoin("test", sdk.NewInt(1000000000000000000))))
+	err := app.AllianceKeeper.CreateAlliance(ctx, &types.MsgCreateAllianceProposal{
+		Title:                "",
+		Description:          "",
+		Denom:                "test",
+		RewardWeight:         sdk.MustNewDecFromStr("0.03"),
+		TakeRate:             sdk.MustNewDecFromStr("0.02"),
+		RewardChangeRate:     sdk.MustNewDecFromStr("0.01"),
+		RewardChangeInterval: time.Second * 60,
+	})
+	require.NoError(t, err)
+
+	val0, err := app.AllianceKeeper.GetAllianceValidator(ctx, vals[0])
+	require.NoError(t, err)
+	val1, err := app.AllianceKeeper.GetAllianceValidator(ctx, vals[1])
+	require.NoError(t, err)
+
+	_, err = app.AllianceKeeper.Delegate(ctx, dels[0], val0, sdk.NewCoin("test", sdk.NewInt(100033333333333333)))
+	require.NoError(t, err)
+
+	val0, err = app.AllianceKeeper.GetAllianceValidator(ctx, vals[0])
+	require.NoError(t, err)
+	require.Equal(t, sdk.NewDec(100033333333333333), sdk.DecCoins(val0.TotalDelegatorShares).AmountOf("test"))
+
+	lastClaim := ctx.BlockTime()
+	ctx = ctx.WithBlockTime(ctx.BlockTime().Add(time.Hour))
+	assets := app.AllianceKeeper.GetAllAssets(ctx)
+	_, err = app.AllianceKeeper.DeductAssetsWithTakeRate(ctx, lastClaim, assets)
+	require.NoError(t, err)
+
+	asset, _ := app.AllianceKeeper.GetAssetByDenom(ctx, "test")
+
+	del0, found := app.AllianceKeeper.GetDelegation(ctx, dels[0], val0, "test")
+	require.True(t, found)
+	tokens := types.GetDelegationTokens(del0, val0, asset)
+	_, err = app.AllianceKeeper.Redelegate(ctx, dels[0], val0, val1, tokens)
+	require.NoError(t, err)
+
+	_, found = app.AllianceKeeper.GetDelegation(ctx, dels[0], val0, "test")
+	require.False(t, found)
+
+	val0, err = app.AllianceKeeper.GetAllianceValidator(ctx, vals[0])
+	require.NoError(t, err)
+
+	require.Equal(t, sdk.ZeroDec(), sdk.DecCoins(val0.ValidatorShares).AmountOf("test"))
+
+	_, err = app.AllianceKeeper.Delegate(ctx, dels[0], val0, sdk.NewCoin("test", sdk.NewInt(33333)))
+	require.NoError(t, err)
+
+	_, stop := alliance.RunAllInvariants(ctx, app.AllianceKeeper)
+	require.False(t, stop)
 }
 
 // Tests delegating a small amount that triggers a re-balancing event that adds < 1 utoken to a validator.


### PR DESCRIPTION
This PR addresses https://github.com/terra-money/alliance/issues/82 regarding dust delegation issues when delegators cannot undelegate fully due to changes in shares after slashing or take rate deduction.

At the same time, it also fixes some rounding issues to make sure that we can successfully undelegate all tokens.