### PR TITLE
fix: remove usage of time.Now()

### DIFF
--- a/x/alliance/genesis.go
+++ b/x/alliance/genesis.go
@@ -1,8 +1,6 @@
 package alliance
 
 import (
-	"time"
-
 	"github.com/terra-money/alliance/x/alliance/types"
 )
 
@@ -26,11 +24,7 @@ func ValidateGenesis(data *types.GenesisState) error {
 
 func DefaultGenesisState() *types.GenesisState {
 	return &types.GenesisState{
-		Params: types.Params{
-			RewardDelayTime:       time.Hour * 24 * 7,
-			TakeRateClaimInterval: time.Minute * 5,
-			LastTakeRateClaimTime: time.Now(),
-		},
+		Params:                     types.DefaultParams(),
 		Assets:                     []types.AllianceAsset{},
 		ValidatorInfos:             []types.ValidatorInfoState{},
 		RewardWeightChangeSnaphots: []types.RewardWeightChangeSnapshotState{},

--- a/x/alliance/keeper/tests/asset_test.go
+++ b/x/alliance/keeper/tests/asset_test.go
@@ -1042,9 +1042,7 @@ func TestClaimTakeRateForNewlyAddedAssets(t *testing.T) {
 
 	// Last take rate claim time should be updated even though nothing has been taxed
 	lastClaimTime := app.AllianceKeeper.LastRewardClaimTime(ctx)
-
-	// Adding a second here since last claim time always increments by the claim time interval
-	require.Equal(t, blockTime, lastClaimTime.Add(time.Second))
+	require.Equal(t, blockTime, lastClaimTime)
 
 	err = app.AllianceKeeper.CreateAlliance(ctx, &types.MsgCreateAllianceProposal{
 		Title:                "New alliance",

--- a/x/alliance/keeper/tests/delegation_test.go
+++ b/x/alliance/keeper/tests/delegation_test.go
@@ -684,8 +684,10 @@ func TestUndelegateAfterClaimingTakeRate(t *testing.T) {
 	app, ctx := createTestContext(t)
 	startTime := time.Now()
 	ctx = ctx.WithBlockTime(startTime).WithBlockHeight(1)
+	params := types.DefaultParams()
+	params.LastTakeRateClaimTime = startTime
 	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
-		Params: types.DefaultParams(),
+		Params: params,
 		Assets: []types.AllianceAsset{
 			types.NewAllianceAsset(AllianceDenom, sdk.NewDec(2), sdk.ZeroDec(), sdk.NewDec(5), sdk.NewDec(0), ctx.BlockTime()),
 			types.NewAllianceAsset(AllianceDenomTwo, sdk.NewDec(10), sdk.NewDec(2), sdk.NewDec(12), sdk.MustNewDecFromStr("0.5"), ctx.BlockTime()),

--- a/x/alliance/keeper/tests/genesis_test.go
+++ b/x/alliance/keeper/tests/genesis_test.go
@@ -143,3 +143,18 @@ func TestExportAndImportGenesis(t *testing.T) {
 		iter2.Next()
 	}
 }
+
+func TestGenesisLastRewardClaimTime(t *testing.T) {
+	app, ctx := createTestContext(t)
+	ctx = ctx.WithBlockTime(time.Now()).WithBlockHeight(1)
+	params := types.DefaultParams()
+	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
+		Params: params,
+		Assets: []types.AllianceAsset{},
+	})
+
+	assets := app.AllianceKeeper.GetAllAssets(ctx)
+	_, err := app.AllianceKeeper.DeductAssetsHook(ctx, assets)
+	require.NoError(t, err)
+	require.Equal(t, app.AllianceKeeper.LastRewardClaimTime(ctx), ctx.BlockTime())
+}

--- a/x/alliance/tests/e2e/delegate_undelegate_test.go
+++ b/x/alliance/tests/e2e/delegate_undelegate_test.go
@@ -142,8 +142,10 @@ func TestDelegatingASmallAmount(t *testing.T) {
 	))
 	startTime := time.Now()
 	ctx = ctx.WithBlockTime(startTime).WithBlockHeight(1)
+	params := types.DefaultParams()
+	params.LastTakeRateClaimTime = startTime
 	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
-		Params: types.DefaultParams(),
+		Params: params,
 		Assets: []types.AllianceAsset{
 			types.NewAllianceAsset(allianceAsset1, sdk.NewDec(2), sdk.NewDec(0), sdk.NewDec(5), sdk.NewDec(0), ctx.BlockTime()),
 			types.NewAllianceAsset(allianceAsset2, sdk.NewDec(10), sdk.NewDec(2), sdk.NewDec(12), sdk.MustNewDecFromStr("0.1"), ctx.BlockTime()),
@@ -252,8 +254,10 @@ func TestDelegateAndUndelegateWithSmallAmounts(t *testing.T) {
 	))
 	startTime := time.Now()
 	ctx = ctx.WithBlockTime(startTime).WithBlockHeight(1)
+	params := types.DefaultParams()
+	params.LastTakeRateClaimTime = startTime
 	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
-		Params: types.DefaultParams(),
+		Params: params,
 		Assets: []types.AllianceAsset{
 			types.NewAllianceAsset(allianceAsset1, sdk.NewDec(2), sdk.NewDec(0), sdk.NewDec(5), sdk.NewDec(0), ctx.BlockTime()),
 			types.NewAllianceAsset(allianceAsset2, sdk.NewDec(10), sdk.NewDec(2), sdk.NewDec(12), sdk.MustNewDecFromStr("0.1"), ctx.BlockTime()),
@@ -317,8 +321,10 @@ func TestUnDelegatingSlightlyMoreCoin(t *testing.T) {
 	))
 	startTime := time.Now()
 	ctx = ctx.WithBlockTime(startTime).WithBlockHeight(1)
+	params := types.DefaultParams()
+	params.LastTakeRateClaimTime = startTime
 	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
-		Params: types.DefaultParams(),
+		Params: params,
 		Assets: []types.AllianceAsset{
 			types.NewAllianceAsset(allianceAsset1, sdk.NewDec(2), sdk.NewDec(0), sdk.NewDec(5), sdk.NewDec(0), ctx.BlockTime()),
 			types.NewAllianceAsset(allianceAsset2, sdk.NewDec(10), sdk.NewDec(2), sdk.NewDec(12), sdk.MustNewDecFromStr("0.1"), ctx.BlockTime()),
@@ -380,8 +386,10 @@ func TestReDelegatingSlightlyMoreCoin(t *testing.T) {
 	))
 	startTime := time.Now()
 	ctx = ctx.WithBlockTime(startTime).WithBlockHeight(1)
+	params := types.DefaultParams()
+	params.LastTakeRateClaimTime = startTime
 	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
-		Params: types.DefaultParams(),
+		Params: params,
 		Assets: []types.AllianceAsset{
 			types.NewAllianceAsset(allianceAsset1, sdk.NewDec(2), sdk.NewDec(0), sdk.NewDec(5), sdk.NewDec(0), ctx.BlockTime()),
 			types.NewAllianceAsset(allianceAsset2, sdk.NewDec(10), sdk.NewDec(2), sdk.NewDec(12), sdk.MustNewDecFromStr("0.1"), ctx.BlockTime()),

--- a/x/alliance/types/params.go
+++ b/x/alliance/types/params.go
@@ -49,7 +49,7 @@ func NewParams() Params {
 	return Params{
 		RewardDelayTime:       time.Hour * 24 * 7,
 		TakeRateClaimInterval: time.Minute * 5,
-		LastTakeRateClaimTime: time.Now(),
+		LastTakeRateClaimTime: time.Time{},
 	}
 }
 


### PR DESCRIPTION
Using `time.Now()` in the default genesis breaks chains that upgrade and include the alliance module since time is different on every machine. 

Use 0 time as default and let the endblocker update the time when the asset take rate hook is triggered.