### PR TITLE
feat: alliance sender

### DIFF
--- a/x/alliance/keeper/delegation.go
+++ b/x/alliance/keeper/delegation.go
@@ -57,6 +57,7 @@ func (k Keeper) Delegate(ctx sdk.Context, delAddr sdk.AccAddress, validator type
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeDelegate,
+			sdk.NewAttribute(types.AttributeKeySender, delAddr.String()),
 			sdk.NewAttribute(types.AttributeKeyValidator, validator.OperatorAddress),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, coin.Amount.String()),
 			sdk.NewAttribute(types.AttributeKeyNewShares, newValidatorShares.String()),
@@ -146,6 +147,7 @@ func (k Keeper) Redelegate(ctx sdk.Context, delAddr sdk.AccAddress, srcVal types
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeRedelegate,
+			sdk.NewAttribute(types.AttributeKeySender, delAddr.String()),
 			sdk.NewAttribute(types.AttributeKeySrcValidator, srcVal.OperatorAddress),
 			sdk.NewAttribute(types.AttributeKeyDstValidator, dstVal.OperatorAddress),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, coin.Amount.String()),
@@ -217,6 +219,7 @@ func (k Keeper) Undelegate(ctx sdk.Context, delAddr sdk.AccAddress, validator ty
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeUndelegate,
+			sdk.NewAttribute(types.AttributeKeySender, delAddr.String()),
 			sdk.NewAttribute(types.AttributeKeyValidator, validator.OperatorAddress),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, coin.Amount.String()),
 			sdk.NewAttribute(types.AttributeKeyCompletionTime, completionTime.Format(time.RFC3339)),

--- a/x/alliance/keeper/reward.go
+++ b/x/alliance/keeper/reward.go
@@ -66,6 +66,7 @@ func (k Keeper) ClaimDelegationRewards(ctx sdk.Context, delAddr sdk.AccAddress, 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTypeClaimDelegationRewards,
+			sdk.NewAttribute(types.AttributeKeySender, delAddr.String()),
 			sdk.NewAttribute(types.AttributeKeyValidator, val.OperatorAddress),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, coins.String()),
 		),

--- a/x/alliance/types/events.go
+++ b/x/alliance/types/events.go
@@ -6,6 +6,7 @@ const (
 	EventTypeRedelegate             = "alliance_redelegate"
 	EventTypeClaimDelegationRewards = "alliance_claim_delegation_rewards"
 
+	AttributeKeySender         = "alliance_sender"
 	AttributeKeyValidator      = "validator"
 	AttributeKeySrcValidator   = "source_validator"
 	AttributeKeyDstValidator   = "destination_validator"


### PR DESCRIPTION
Attribute alliance_sender help to differentiate between the internal blockchain account senders and the account that initiated the transaction. 

As you can observe in the following example is not visible who initiated the transaction but you can see that multiple accounts have send funds when this transaction has been included in the block:


```json
{
    "msg_index": 0,
    "log": "",
    "events": [
        {
            "type": "alliance_claim_delegation_rewards",
            "attributes": [
                {
                    "key": "validator",
                    "value": "atreidesvaloper1jt9w26mpxxjsk63mvd4m2ynj0af09csl9p5drf"
                },
                {
                    "key": "amount",
                    "value": "443967uatr"
                }
            ]
        },
        {
            "type": "alliance_redelegate",
            "attributes": [
                {
                    "key": "source_validator",
                    "value": "atreidesvaloper1jt9w26mpxxjsk63mvd4m2ynj0af09csl9p5drf"
                },
                {
                    "key": "destination_validator",
                    "value": "atreidesvaloper1zk2zxgnpmw4rng4merhdjgs27e84ts3qjxqmsk"
                },
                {
                    "key": "amount",
                    "value": "50000000"
                },
                {
                    "key": "completion_time",
                    "value": "2023-02-10T08:42:27Z"
                }
            ]
        },
        {
            "type": "coin_received",
            "attributes": [
                {
                    "key": "receiver",
                    "value": "atreides1srd5yxrg346qd7mne893gy3g43elh2sw79rf7w"
                },
                {
                    "key": "amount",
                    "value": "936449uatr"
                },
                {
                    "key": "receiver",
                    "value": "atreides14hayt9cet2rfqu6tj0n8d7rnn5d0ng97a0uklp"
                },
                {
                    "key": "amount",
                    "value": "936449uatr"
                },
                {
                    "key": "receiver",
                    "value": "atreides15wzyhjdlv9rg9f7nnazdt8thv8sgzehne5p422"
                },
                {
                    "key": "amount",
                    "value": "443967uatr"
                }
            ]
        },
        {
            "type": "coin_spent",
            "attributes": [
                {
                    "key": "spender",
                    "value": "atreides1jv65s3grqf6v6jl3dp4t6c9t9rk99cd889968q"
                },
                {
                    "key": "amount",
                    "value": "936449uatr"
                },
                {
                    "key": "spender",
                    "value": "atreides1srd5yxrg346qd7mne893gy3g43elh2sw79rf7w"
                },
                {
                    "key": "amount",
                    "value": "936449uatr"
                },
                {
                    "key": "spender",
                    "value": "atreides14hayt9cet2rfqu6tj0n8d7rnn5d0ng97a0uklp"
                },
                {
                    "key": "amount",
                    "value": "443967uatr"
                }
            ]
        },
        {
            "type": "message",
            "attributes": [
                {
                    "key": "action",
                    "value": "/alliance.alliance.MsgRedelegate"
                },
                {
                    "key": "sender",
                    "value": "atreides1jv65s3grqf6v6jl3dp4t6c9t9rk99cd889968q"
                },
                {
                    "key": "sender",
                    "value": "atreides1srd5yxrg346qd7mne893gy3g43elh2sw79rf7w"
                },
                {
                    "key": "sender",
                    "value": "atreides14hayt9cet2rfqu6tj0n8d7rnn5d0ng97a0uklp"
                }
            ]
        },
        {
            "type": "transfer",
            "attributes": [
                {
                    "key": "recipient",
                    "value": "atreides1srd5yxrg346qd7mne893gy3g43elh2sw79rf7w"
                },
                {
                    "key": "sender",
                    "value": "atreides1jv65s3grqf6v6jl3dp4t6c9t9rk99cd889968q"
                },
                {
                    "key": "amount",
                    "value": "936449uatr"
                },
                {
                    "key": "recipient",
                    "value": "atreides14hayt9cet2rfqu6tj0n8d7rnn5d0ng97a0uklp"
                },
                {
                    "key": "sender",
                    "value": "atreides1srd5yxrg346qd7mne893gy3g43elh2sw79rf7w"
                },
                {
                    "key": "amount",
                    "value": "936449uatr"
                },
                {
                    "key": "recipient",
                    "value": "atreides15wzyhjdlv9rg9f7nnazdt8thv8sgzehne5p422"
                },
                {
                    "key": "sender",
                    "value": "atreides14hayt9cet2rfqu6tj0n8d7rnn5d0ng97a0uklp"
                },
                {
                    "key": "amount",
                    "value": "443967uatr"
                }
            ]
        },
        {
            "type": "withdraw_rewards",
            "attributes": [
                {
                    "key": "amount",
                    "value": "936449uatr"
                },
                {
                    "key": "validator",
                    "value": "atreidesvaloper1jt9w26mpxxjsk63mvd4m2ynj0af09csl9p5drf"
                }
            ]
        }
    ],
    "eventsByType": {
        "alliance_claim_delegation_rewards": {
            "validator": [
                "atreidesvaloper1jt9w26mpxxjsk63mvd4m2ynj0af09csl9p5drf"
            ],
            "amount": [
                "443967uatr"
            ]
        },
        "alliance_redelegate": {
            "source_validator": [
                "atreidesvaloper1jt9w26mpxxjsk63mvd4m2ynj0af09csl9p5drf"
            ],
            "destination_validator": [
                "atreidesvaloper1zk2zxgnpmw4rng4merhdjgs27e84ts3qjxqmsk"
            ],
            "amount": [
                "50000000"
            ],
            "completion_time": [
                "2023-02-10T08:42:27Z"
            ]
        },
        "coin_received": {
            "receiver": [
                "atreides1srd5yxrg346qd7mne893gy3g43elh2sw79rf7w",
                "atreides14hayt9cet2rfqu6tj0n8d7rnn5d0ng97a0uklp",
                "atreides15wzyhjdlv9rg9f7nnazdt8thv8sgzehne5p422"
            ],
            "amount": [
                "936449uatr",
                "936449uatr",
                "443967uatr"
            ]
        },
        "coin_spent": {
            "spender": [
                "atreides1jv65s3grqf6v6jl3dp4t6c9t9rk99cd889968q",
                "atreides1srd5yxrg346qd7mne893gy3g43elh2sw79rf7w",
                "atreides14hayt9cet2rfqu6tj0n8d7rnn5d0ng97a0uklp"
            ],
            "amount": [
                "936449uatr",
                "936449uatr",
                "443967uatr"
            ]
        },
        "message": {
            "action": [
                "/alliance.alliance.MsgRedelegate"
            ],
            "sender": [
                "atreides1jv65s3grqf6v6jl3dp4t6c9t9rk99cd889968q",
                "atreides1srd5yxrg346qd7mne893gy3g43elh2sw79rf7w",
                "atreides14hayt9cet2rfqu6tj0n8d7rnn5d0ng97a0uklp"
            ]
        },
        "transfer": {
            "recipient": [
                "atreides1srd5yxrg346qd7mne893gy3g43elh2sw79rf7w",
                "atreides14hayt9cet2rfqu6tj0n8d7rnn5d0ng97a0uklp",
                "atreides15wzyhjdlv9rg9f7nnazdt8thv8sgzehne5p422"
            ],
            "sender": [
                "atreides1jv65s3grqf6v6jl3dp4t6c9t9rk99cd889968q",
                "atreides1srd5yxrg346qd7mne893gy3g43elh2sw79rf7w",
                "atreides14hayt9cet2rfqu6tj0n8d7rnn5d0ng97a0uklp"
            ],
            "amount": [
                "936449uatr",
                "936449uatr",
                "443967uatr"
            ]
        },
        "withdraw_rewards": {
            "amount": [
                "936449uatr"
            ],
            "validator": [
                "atreidesvaloper1jt9w26mpxxjsk63mvd4m2ynj0af09csl9p5drf"
            ]
        }
    }
}
```