### PR TITLE
fix: claim rewards before alliance start time

### DIFF
--- a/x/alliance/keeper/grpc_query.go
+++ b/x/alliance/keeper/grpc_query.go
@@ -231,9 +231,15 @@ func (k QueryServer) AllianceDelegationRewards(context context.Context, request 
 	if err != nil {
 		return nil, err
 	}
-	_, found := k.GetAssetByDenom(ctx, request.Denom)
+	asset, found := k.GetAssetByDenom(ctx, request.Denom)
 	if !found {
 		return nil, types.ErrUnknownAsset
+	}
+
+	if ctx.BlockTime().Before(asset.RewardStartTime) {
+		return &types.QueryAllianceDelegationRewardsResponse{
+			Rewards: sdk.NewCoins(),
+		}, nil
 	}
 
 	val, err := k.GetAllianceValidator(ctx, valAddr)

--- a/x/alliance/keeper/reward.go
+++ b/x/alliance/keeper/reward.go
@@ -39,6 +39,11 @@ func (k Keeper) ClaimDelegationRewards(ctx sdk.Context, delAddr sdk.AccAddress, 
 	if !found {
 		return nil, types.ErrUnknownAsset
 	}
+
+	if ctx.BlockTime().Before(asset.RewardStartTime) {
+		return nil, types.ErrRewardsStartTimeNotMature
+	}
+
 	delegation, found := k.GetDelegation(ctx, delAddr, val, denom)
 	if !found {
 		return sdk.Coins{}, stakingtypes.ErrNoDelegatorForAddress

--- a/x/alliance/tests/e2e/delegate_undelegate_test.go
+++ b/x/alliance/tests/e2e/delegate_undelegate_test.go
@@ -24,6 +24,11 @@ var (
 // applied will not cause a division by zero error.
 func TestDelegateThenTakeRateThenUndelegate(t *testing.T) {
 	app, ctx, vals, dels := setupApp(t, 5, 2, sdk.NewCoins(sdk.NewCoin("test", sdk.NewInt(1000000000000000000))))
+	app.AllianceKeeper.SetParams(ctx, types.Params{
+		RewardDelayTime:       0,
+		TakeRateClaimInterval: time.Minute * 5,
+		LastTakeRateClaimTime: ctx.BlockTime(),
+	})
 	err := app.AllianceKeeper.CreateAlliance(ctx, &types.MsgCreateAllianceProposal{
 		Title:                "",
 		Description:          "",
@@ -80,6 +85,11 @@ func TestDelegateThenTakeRateThenUndelegate(t *testing.T) {
 // applied will not cause a division by zero error. Also ensure that dust delegations are not kept around
 func TestDelegateThenTakeRateThenRedelegate(t *testing.T) {
 	app, ctx, vals, dels := setupApp(t, 5, 2, sdk.NewCoins(sdk.NewCoin("test", sdk.NewInt(1000000000000000000))))
+	app.AllianceKeeper.SetParams(ctx, types.Params{
+		RewardDelayTime:       0,
+		TakeRateClaimInterval: time.Minute * 5,
+		LastTakeRateClaimTime: ctx.BlockTime(),
+	})
 	err := app.AllianceKeeper.CreateAlliance(ctx, &types.MsgCreateAllianceProposal{
 		Title:                "",
 		Description:          "",

--- a/x/alliance/types/errors.go
+++ b/x/alliance/types/errors.go
@@ -16,4 +16,6 @@ var (
 	ErrUnknownAsset = sdkerrors.Register(ModuleName, 30, "alliance asset is not whitelisted")
 
 	ErrRewardWeightOutOfBound = sdkerrors.Register(ModuleName, 40, "alliance asset must be between reward_weight_range")
+
+	ErrRewardsStartTimeNotMature = sdkerrors.Register(ModuleName, 50, "alliance is not generating rewards yet because reward_start_time is in the future")
 )


### PR DESCRIPTION
This pull request solves the issue  [#113](https://github.com/terra-money/alliance/issues/113) assures that when querying the `AllianceDelegationRewards` or executing the `ClaimDelegationRewards` method the user cannot claim rewards before the `Alliance.RewardStartTime`.