### PR TITLE
fix: optimized reward claiming to only for alliance changes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -433,7 +433,7 @@ func New(
 	// register the staking hooks
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
 	app.StakingKeeper = *stakingKeeper.SetHooks(
-		stakingtypes.NewMultiStakingHooks(app.AllianceKeeper.StakingHooks(), app.DistrKeeper.Hooks(), app.SlashingKeeper.Hooks()),
+		stakingtypes.NewMultiStakingHooks(app.DistrKeeper.Hooks(), app.SlashingKeeper.Hooks(), app.AllianceKeeper.StakingHooks()),
 	)
 
 	// ... other modules keepers

--- a/x/alliance/keeper/asset.go
+++ b/x/alliance/keeper/asset.go
@@ -146,6 +146,10 @@ func (k Keeper) RebalanceBondTokenWeights(ctx sdk.Context, assets []*types.Allia
 			if err != nil {
 				return err
 			}
+			_, err = k.ClaimValidatorRewards(ctx, validator)
+			if err != nil {
+				return err
+			}
 			_, err = k.stakingKeeper.Delegate(ctx, moduleAddr, bondAmount, stakingtypes.Unbonded, *validator.Validator, true)
 			if err != nil {
 				return err
@@ -158,6 +162,10 @@ func (k Keeper) RebalanceBondTokenWeights(ctx sdk.Context, assets []*types.Allia
 				continue
 			}
 			sharesToUnbond, err := k.stakingKeeper.ValidateUnbondAmount(ctx, moduleAddr, validator.GetOperator(), unbondAmount)
+			if err != nil {
+				return err
+			}
+			_, err = k.ClaimValidatorRewards(ctx, validator)
 			if err != nil {
 				return err
 			}

--- a/x/alliance/keeper/hooks.go
+++ b/x/alliance/keeper/hooks.go
@@ -39,14 +39,6 @@ func (h Hooks) BeforeDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, 
 }
 
 func (h Hooks) BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
-	val, err := h.k.GetAllianceValidator(ctx, valAddr)
-	if err != nil {
-		return err
-	}
-	_, err = h.k.ClaimValidatorRewards(ctx, val)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
This is a follow-up to the PR: https://github.com/terra-money/alliance/pull/117

Optimized the rewards claiming flow to only claim when the staking changes affects the alliance module.