### PR TITLE
fix: validate reward change interval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
+PWD := $(shell pwd)
 BINDIR ?= $(GOPATH)/bin
 SIMAPP = ./app
 
@@ -113,7 +114,7 @@ lint: format-tools
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "*.pb.go" -not -path "*pb.gw.go" | xargs gofumpt -d
 
 lint-docker:
-	docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.49.0-alpine golangci-lint run
+	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.49.0-alpine golangci-lint run
 
 format: format-tools
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "*.pb.go" -not -path "*pb.gw.go" | xargs gofumpt -w

--- a/x/alliance/types/gov.go
+++ b/x/alliance/types/gov.go
@@ -74,6 +74,10 @@ func (m *MsgCreateAllianceProposal) ValidateBasic() error {
 		return status.Errorf(codes.InvalidArgument, "Alliance rewardChangeRate must be strictly a positive number")
 	}
 
+	if m.RewardChangeInterval < 0 {
+		return status.Errorf(codes.InvalidArgument, "Alliance rewardChangeInterval must be strictly a positive number")
+	}
+
 	return nil
 }
 
@@ -108,6 +112,10 @@ func (m *MsgUpdateAllianceProposal) ValidateBasic() error {
 
 	if m.RewardChangeRate.IsZero() || m.RewardChangeRate.IsNegative() {
 		return status.Errorf(codes.InvalidArgument, "Alliance rewardChangeRate must be strictly a positive number")
+	}
+
+	if m.RewardChangeInterval < 0 {
+		return status.Errorf(codes.InvalidArgument, "Alliance rewardChangeInterval must be strictly a positive number")
 	}
 
 	return nil

--- a/x/alliance/types/tests/types_test.go
+++ b/x/alliance/types/tests/types_test.go
@@ -105,3 +105,37 @@ func TestProposalsContent(t *testing.T) {
 		})
 	}
 }
+
+func TestInvalidProposalsContent(t *testing.T) {
+	cases := map[string]struct {
+		p     govtypes.Content
+		title string
+		desc  string
+		typ   string
+		str   string
+	}{
+		"msg_create_alliance_proposal": {
+			p:     types.NewMsgCreateAllianceProposal("Alliance1", "Alliance with 1", "ibc/denom1", sdk.NewDec(1), types.RewardWeightRange{Min: sdk.NewDec(0), Max: sdk.NewDec(5)}, sdk.NewDec(1), sdk.NewDec(1), -time.Second),
+			title: "Alliance1",
+			desc:  "Alliance with 1",
+			typ:   "msg_create_alliance_proposal",
+		},
+		"msg_update_alliance_proposal": {
+			p:     types.NewMsgUpdateAllianceProposal("Alliance2", "Alliance with 2", "ibc/denom2", sdk.NewDec(2), sdk.NewDec(2), sdk.NewDec(2), -time.Hour),
+			title: "Alliance2",
+			desc:  "Alliance with 2",
+			typ:   "msg_update_alliance_proposal",
+		},
+	}
+
+	cdc := codec.NewLegacyAmino()
+	govtypes.RegisterLegacyAminoCodec(cdc)
+	types.RegisterLegacyAminoCodec(cdc)
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.p.ValidateBasic()
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Reward change interval was not validated to be non-negative. Since duration can be a negative number, we need to perform the validation when the alliance is voted in through governance.