### PR TITLE
Fix/reward rate update time

### DIFF
--- a/x/alliance/abci.go
+++ b/x/alliance/abci.go
@@ -24,7 +24,9 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) []abci.ValidatorUpdate {
 	if _, err := k.DeductAssetsHook(ctx, assets); err != nil {
 		panic(fmt.Errorf("failed to deduct take rate from alliance in x/alliance module: %s", err))
 	}
-	k.RewardWeightChangeHook(ctx, assets)
+	if err := k.RewardWeightChangeHook(ctx, assets); err != nil {
+		panic(fmt.Errorf("failed to update assets reward weights in x/alliance module: %s", err))
+	}
 	if err := k.RebalanceHook(ctx, assets); err != nil {
 		panic(fmt.Errorf("failed to rebalance assets in x/alliance module: %s", err))
 	}

--- a/x/alliance/keeper/asset.go
+++ b/x/alliance/keeper/asset.go
@@ -69,7 +69,7 @@ func (k Keeper) UpdateAllianceAsset(ctx sdk.Context, newAsset types.AllianceAsse
 	if !newAsset.RewardChangeRate.Equal(asset.RewardChangeRate) || newAsset.RewardChangeInterval != asset.RewardChangeInterval {
 		// And if there were no reward changes scheduled previously, start the counter from now
 		if asset.RewardChangeRate.Equal(sdk.OneDec()) || asset.RewardChangeInterval == 0 {
-			asset.LastRewardChangeTime = ctx.BlockTime()
+			newAsset.LastRewardChangeTime = ctx.BlockTime()
 		}
 		// Else do nothing since there is already a change that was scheduled.
 		// The next trigger will use the new reward change and reward interval

--- a/x/alliance/keeper/asset.go
+++ b/x/alliance/keeper/asset.go
@@ -363,7 +363,7 @@ func (k Keeper) IterateAllWeightChangeSnapshot(ctx sdk.Context, cb func(denom st
 	}
 }
 
-func (k Keeper) RewardWeightChangeHook(ctx sdk.Context, assets []*types.AllianceAsset) {
+func (k Keeper) RewardWeightChangeHook(ctx sdk.Context, assets []*types.AllianceAsset) error {
 	for _, asset := range assets {
 		// If no reward changes are required, skip
 		if asset.RewardChangeInterval == 0 || asset.RewardChangeRate.Equal(sdk.OneDec()) {
@@ -387,6 +387,10 @@ func (k Keeper) RewardWeightChangeHook(ctx sdk.Context, assets []*types.Alliance
 		}
 		asset.LastRewardChangeTime = asset.LastRewardChangeTime.Add(asset.RewardChangeInterval * time.Duration(intervalsSinceLastClaim))
 		k.QueueAssetRebalanceEvent(ctx)
-		k.UpdateAllianceAsset(ctx, *asset) //nolint:errcheck
+		err := k.UpdateAllianceAsset(ctx, *asset)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/x/alliance/keeper/tests/asset_test.go
+++ b/x/alliance/keeper/tests/asset_test.go
@@ -622,13 +622,16 @@ func TestRewardRangeWithChangeRateOverTime(t *testing.T) {
 	asset, _ := app.AllianceKeeper.GetAssetByDenom(ctx, AllianceDenom)
 	assets := app.AllianceKeeper.GetAllAssets(ctx)
 	// Running the decay hook now should do nothing
-	app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+	err := app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+	require.NoError(t, err)
 
 	// Move block time to after change interval + one year
 	ctx = ctx.WithBlockTime(asset.RewardStartTime.Add(decayInterval * 2))
 
 	// Running the decay hook should update reward weight
-	app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+	err = app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+	require.NoError(t, err)
+
 	updatedAsset, _ := app.AllianceKeeper.GetAssetByDenom(ctx, AllianceDenom)
 	require.Equal(t, types.AllianceAsset{
 		Denom:                AllianceDenom,
@@ -704,13 +707,15 @@ func TestRewardWeightDecay(t *testing.T) {
 
 	assets := app.AllianceKeeper.GetAllAssets(ctx)
 	// Running the decay hook now should do nothing
-	app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+	err = app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+	require.NoError(t, err)
 
 	// Move block time to after change interval + one year
 	ctx = ctx.WithBlockTime(asset.RewardStartTime.Add(decayInterval))
 
 	// Running the decay hook should update reward weight
-	app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+	err = app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+	require.NoError(t, err)
 	updatedAsset, _ := app.AllianceKeeper.GetAssetByDenom(ctx, AllianceDenom)
 	require.Equal(t, types.AllianceAsset{
 		Denom:                AllianceDenom,
@@ -841,7 +846,8 @@ func TestRewardWeightDecayOverTime(t *testing.T) {
 		ctx = ctx.WithBlockTime(ctx.BlockTime().Add(blockTime)).WithBlockHeight(ctx.BlockHeight() + 1)
 		assets = app.AllianceKeeper.GetAllAssets(ctx)
 		// Running the decay hook should update reward weight
-		app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+		err = app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+		require.NoError(t, err)
 	}
 
 	// time passed minus reward delay time (rewards and decay only start after the delay)

--- a/x/alliance/keeper/tests/reward_test.go
+++ b/x/alliance/keeper/tests/reward_test.go
@@ -769,7 +769,8 @@ func TestRewardClaimingAfterRatesDecay(t *testing.T) {
 	assets = app.AllianceKeeper.GetAllAssets(ctx)
 
 	// Running the decay hook should update reward weight
-	app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+	err = app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+	require.NoError(t, err)
 	asset, _ := app.AllianceKeeper.GetAssetByDenom(ctx, AllianceDenom)
 	require.Equal(t, sdk.MustNewDecFromStr("0.25"), asset.RewardWeight)
 	err = app.AllianceKeeper.AddAssetsToRewardPool(ctx, addrs[0], val0, sdk.NewCoins(sdk.NewCoin(bondDenom, sdk.NewInt(1000_000))))

--- a/x/alliance/tests/benchmark/benchmark_test.go
+++ b/x/alliance/tests/benchmark/benchmark_test.go
@@ -103,7 +103,10 @@ func TestRunBenchmarks(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+		err = app.AllianceKeeper.RewardWeightChangeHook(ctx, assets)
+		if err != nil {
+			panic(err)
+		}
 		err = app.AllianceKeeper.RebalanceHook(ctx, assets)
 		if err != nil {
 			panic(err)

--- a/x/alliance/types/keys.go
+++ b/x/alliance/types/keys.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	// ModuleName is the name of the staking module
+	// ModuleName is the name of the alliance module
 	ModuleName = "alliance"
 
 	// RewardsPoolName is the name of the module account for rewards
@@ -17,10 +17,10 @@ const (
 	// StoreKey is the string store representation
 	StoreKey = ModuleName
 
-	// QuerierRoute is the querier route for the staking module
+	// QuerierRoute is the querier route for the alliance module
 	QuerierRoute = ModuleName
 
-	// RouterKey is the msg router key for the staking module
+	// RouterKey is the msg router key for the alliance module
 	RouterKey = ModuleName
 
 	// MemStoreKey defines the in-memory store key


### PR DESCRIPTION
Audit findings:
1. Not handling errors from `UpdateAllianceAsset`
2. Reward weight last update time not updated from a new reward weight rate is added