### PR TITLE
fix: move some function checks inside

### DIFF
--- a/x/alliance/keeper/asset.go
+++ b/x/alliance/keeper/asset.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	"math"
 	"time"
 
@@ -235,7 +236,15 @@ func (k Keeper) GetAssetByDenom(ctx sdk.Context, denom string) (asset types.Alli
 	return asset, true
 }
 
-func (k Keeper) DeleteAsset(ctx sdk.Context, denom string) {
+func (k Keeper) DeleteAsset(ctx sdk.Context, asset types.AllianceAsset) error {
+	if asset.TotalTokens.GT(sdk.ZeroInt()) {
+		return fmt.Errorf("cannot delete alliance assets that still have tokens")
+	}
+	k.deleteAsset(ctx, asset.Denom)
+	return nil
+}
+
+func (k Keeper) deleteAsset(ctx sdk.Context, denom string) {
 	store := ctx.KVStore(k.storeKey)
 	assetKey := types.GetAssetKey(denom)
 	store.Delete(assetKey)

--- a/x/alliance/keeper/proposal.go
+++ b/x/alliance/keeper/proposal.go
@@ -70,7 +70,10 @@ func (k Keeper) DeleteAlliance(ctx context.Context, req *types.MsgDeleteAlliance
 		return status.Errorf(codes.Internal, "Asset cannot be deleted because there are still %s delegations associated with it", asset.TotalTokens)
 	}
 
-	k.DeleteAsset(sdkCtx, req.Denom)
+	err := k.DeleteAsset(sdkCtx, asset)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Moved function guards inside so that calls do not have to check if the conditions have been met before calling them