### PR TITLE
fix: use a reasonable take rate for simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ test-e2e:
 test-benchmark:
 	@VERSION=$(VERSION) go test -v -mod=readonly -tags='ledger test_ledger_mock' github.com/terra-money/alliance/x/alliance/tests/benchmark
 
+.PHONY: test test-unit test-e2e test-benchmark
 ###############################################################################
 ###                                Linting                                  ###
 ###############################################################################
@@ -121,30 +122,14 @@ format: format-tools
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "*.pb.go" -not -path "*pb.gw.go" | xargs misspell -w
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "*.pb.go" -not -path "*pb.gw.go" | xargs goimports -w -local github.com/terra-money/alliance
 
-
 ###############################################################################
 ###                                Protobuf                                 ###
 ###############################################################################
 PROTO_BUILDER_IMAGE=tendermintdev/sdk-proto-gen:v0.7
 
-proto-all: proto-swagger-gen proto-gen
-
 proto-gen:
 	@echo "Generating Protobuf files"
 	$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(PROTO_BUILDER_IMAGE) sh ./scripts/protocgen.sh
-
-
-###############################################################################
-###                           Local Testnet (Single Node)                   ###
-###############################################################################
-
-serve: install init start
-
-init:
-	cd scripts/local && bash init.sh
-
-start:
-	cd scripts/local && bash start.sh
 
 ###############################################################################
 ###                                Local Testnet (docker)                   ###

--- a/app/app.go
+++ b/app/app.go
@@ -812,7 +812,7 @@ func (app *App) GetSubspace(moduleName string) paramstypes.Subspace {
 
 // RegisterAPIRoutes registers all application module routes with the provided
 // API server.
-func (app *App) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.APIConfig) {
+func (app *App) RegisterAPIRoutes(apiSvr *api.Server, _ config.APIConfig) {
 	clientCtx := apiSvr.ClientCtx
 	// Register new tx routes from grpc-gateway.
 	authtx.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAppExportAndBlockedAddrs(t *testing.T) {
-	app := Setup(t, false)
+	app := Setup(t)
 	_, err := app.ExportAppStateAndValidators(true, []string{})
 	require.NoError(t, err, "ExportAppStateAndValidators should not have an error")
 

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -37,7 +37,7 @@ import (
 )
 
 // Setup initializes a new SimApp. A Nop logger is set in SimApp.
-func Setup(t *testing.T, isCheckTx bool) *App {
+func Setup(t *testing.T) *App {
 	t.Helper()
 
 	privVal := mock.NewPV()
@@ -194,7 +194,7 @@ func MakeTestEncodingConfig() params.EncodingConfig {
 type EmptyAppOptions struct{}
 
 // Get implements AppOptions
-func (ao EmptyAppOptions) Get(o string) interface{} {
+func (ao EmptyAppOptions) Get(_ string) interface{} {
 	return nil
 }
 

--- a/x/alliance/keeper/hooks.go
+++ b/x/alliance/keeper/hooks.go
@@ -11,42 +11,42 @@ type Hooks struct {
 
 var _ stakingtypes.StakingHooks = Hooks{}
 
-func (h Hooks) AfterValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) error {
+func (h Hooks) AfterValidatorCreated(_ sdk.Context, _ sdk.ValAddress) error {
 	return nil
 }
 
-func (h Hooks) BeforeValidatorModified(ctx sdk.Context, valAddr sdk.ValAddress) error {
+func (h Hooks) BeforeValidatorModified(_ sdk.Context, _ sdk.ValAddress) error {
 	return nil
 }
 
-func (h Hooks) AfterValidatorRemoved(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) AfterValidatorRemoved(ctx sdk.Context, _ sdk.ConsAddress, _ sdk.ValAddress) error {
 	h.k.QueueAssetRebalanceEvent(ctx)
 	return nil
 }
 
-func (h Hooks) AfterValidatorBonded(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) AfterValidatorBonded(ctx sdk.Context, _ sdk.ConsAddress, _ sdk.ValAddress) error {
 	h.k.QueueAssetRebalanceEvent(ctx)
 	return nil
 }
 
-func (h Hooks) AfterValidatorBeginUnbonding(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) AfterValidatorBeginUnbonding(ctx sdk.Context, _ sdk.ConsAddress, _ sdk.ValAddress) error {
 	h.k.QueueAssetRebalanceEvent(ctx)
 	return nil
 }
 
-func (h Hooks) BeforeDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) BeforeDelegationCreated(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	return nil
 }
 
-func (h Hooks) BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) BeforeDelegationSharesModified(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	return nil
 }
 
-func (h Hooks) BeforeDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) BeforeDelegationRemoved(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	return nil
 }
 
-func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) AfterDelegationModified(ctx sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	h.k.QueueAssetRebalanceEvent(ctx)
 	return nil
 }

--- a/x/alliance/keeper/tests/keeper_test.go
+++ b/x/alliance/keeper/tests/keeper_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func createTestContext(t *testing.T) (*app.App, sdk.Context) {
-	app := app.Setup(t, false)
+	app := app.Setup(t)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 	return app, ctx
 }

--- a/x/alliance/module.go
+++ b/x/alliance/module.go
@@ -69,7 +69,7 @@ func (a AppModuleBasic) DefaultGenesis(jsonCodec codec.JSONCodec) json.RawMessag
 	return jsonCodec.MustMarshalJSON(DefaultGenesisState())
 }
 
-func (a AppModuleBasic) ValidateGenesis(jsonCodec codec.JSONCodec, config client.TxEncodingConfig, message json.RawMessage) error {
+func (a AppModuleBasic) ValidateGenesis(jsonCodec codec.JSONCodec, _ client.TxEncodingConfig, message json.RawMessage) error {
 	var genesis types.GenesisState
 	if err := jsonCodec.UnmarshalJSON(message, &genesis); err != nil {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)
@@ -109,7 +109,7 @@ func (a AppModule) InitGenesis(ctx sdk.Context, jsonCodec codec.JSONCodec, messa
 	return a.keeper.InitGenesis(ctx, &genesis)
 }
 
-func (a AppModule) ExportGenesis(ctx sdk.Context, jsonCodec codec.JSONCodec) json.RawMessage {
+func (a AppModule) ExportGenesis(ctx sdk.Context, _ codec.JSONCodec) json.RawMessage {
 	genesis := a.keeper.ExportGenesis(ctx)
 	return a.cdc.MustMarshalJSON(genesis)
 }
@@ -147,18 +147,18 @@ func (a AppModule) GenerateGenesisState(simState *module.SimulationState) {
 	simulation2.RandomizedGenesisState(simState)
 }
 
-func (a AppModule) ProposalContents(simState module.SimulationState) []simtypes.WeightedProposalContent {
+func (a AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalContent {
 	return nil
 }
 
-func (a AppModule) RandomizedParams(r *rand.Rand) []simtypes.ParamChange {
-	return simulation2.ParamChanges(r)
+func (a AppModule) RandomizedParams(_ *rand.Rand) []simtypes.ParamChange {
+	return simulation2.ParamChanges()
 }
 
 func (a AppModule) RegisterStoreDecoder(registry sdk.StoreDecoderRegistry) {
 	registry[types.StoreKey] = simulation2.NewDecodeStore(a.cdc)
 }
 
-func (a AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
-	return simulation2.WeightedOperations(simState.AppParams, a.pcdc, a.accountKeeper, a.bankKeeper, a.stakingKeeper, a.keeper)
+func (a AppModule) WeightedOperations(_ module.SimulationState) []simtypes.WeightedOperation {
+	return simulation2.WeightedOperations(a.pcdc, a.accountKeeper, a.bankKeeper, a.stakingKeeper, a.keeper)
 }

--- a/x/alliance/tests/benchmark/benchmark_test.go
+++ b/x/alliance/tests/benchmark/benchmark_test.go
@@ -81,7 +81,7 @@ func TestRunBenchmarks(t *testing.T) {
 				delegateOperation(ctx, app, r, assets, vals, dels)
 				operations["delegate"]++
 			case 1:
-				redelegateOperation(ctx, app, r, assets, vals, dels)
+				redelegateOperation(ctx, app, r, vals)
 				operations["redelegate"]++
 			case 2:
 				undelegateOperation(ctx, app, r)
@@ -151,7 +151,7 @@ func delegateOperation(ctx sdk.Context, app *test_helpers.App, r *rand.Rand, ass
 	createdDelegations = append(createdDelegations, types.NewDelegation(ctx, delAddr, valAddr, asset.Denom, sdk.ZeroDec(), []types.RewardHistory{}))
 }
 
-func redelegateOperation(ctx sdk.Context, app *test_helpers.App, r *rand.Rand, assets []types.AllianceAsset, vals []sdk.AccAddress, dels []sdk.AccAddress) { //nolint:unparam // assets is unused
+func redelegateOperation(ctx sdk.Context, app *test_helpers.App, r *rand.Rand, vals []sdk.AccAddress) {
 	var delegation types.Delegation
 	if len(createdDelegations) == 0 {
 		return
@@ -172,7 +172,8 @@ func redelegateOperation(ctx sdk.Context, app *test_helpers.App, r *rand.Rand, a
 	}
 
 	dstValAddr := sdk.ValAddress(vals[r.Intn(len(vals)-1)])
-	for ; dstValAddr.Equals(srcValAddr); dstValAddr = sdk.ValAddress(vals[r.Intn(len(vals)-1)]) {
+	for dstValAddr.Equals(srcValAddr) {
+		dstValAddr = sdk.ValAddress(vals[r.Intn(len(vals)-1)])
 	}
 	dstValidator, _ := app.AllianceKeeper.GetAllianceValidator(ctx, dstValAddr)
 

--- a/x/alliance/tests/benchmark/test_helper.go
+++ b/x/alliance/tests/benchmark/test_helper.go
@@ -17,7 +17,7 @@ import (
 )
 
 func SetupApp(t *testing.T, r *rand.Rand, numAssets int, numValidators int, numDelegators int) (app *test_helpers.App, ctx sdk.Context, assets []types.AllianceAsset, valAddrs []sdk.AccAddress, delAddrs []sdk.AccAddress) {
-	app = test_helpers.Setup(t, false)
+	app = test_helpers.Setup(t)
 	ctx = app.BaseApp.NewContext(false, tmproto.Header{})
 	startTime := time.Now()
 	ctx = ctx.WithBlockTime(startTime)

--- a/x/alliance/tests/e2e/test_helper.go
+++ b/x/alliance/tests/e2e/test_helper.go
@@ -13,7 +13,7 @@ import (
 )
 
 func setupApp(t *testing.T, numValidators int, numDelegators int, initBalance sdk.Coins) (app *test_helpers.App, ctx sdk.Context, valAddrs []sdk.ValAddress, delAddrs []sdk.AccAddress) {
-	app = test_helpers.Setup(t, false)
+	app = test_helpers.Setup(t)
 	ctx = app.BaseApp.NewContext(false, tmproto.Header{})
 	startTime := time.Now()
 	ctx = ctx.WithBlockTime(startTime)

--- a/x/alliance/tests/simulation/genesis.go
+++ b/x/alliance/tests/simulation/genesis.go
@@ -40,7 +40,7 @@ func RandomizedGenesisState(simState *module.SimulationState) {
 	var allianceAssets []types.AllianceAsset
 	for i := 0; i < numOfAllianceAssets; i++ {
 		rewardRate := simulation.RandomDecAmount(r, sdk.NewDec(5))
-		takeRate := simulation.RandomDecAmount(r, sdk.MustNewDecFromStr("0.5"))
+		takeRate := simulation.RandomDecAmount(r, sdk.MustNewDecFromStr("0.0005"))
 		startTime := time.Now().Add(time.Duration(simulation.RandIntBetween(r, 60, 60*60*24*3*2)) * time.Second)
 		allianceAssets = append(allianceAssets, types.NewAllianceAsset(fmt.Sprintf("ASSET%d", i), rewardRate, sdk.NewDec(0), sdk.NewDec(15), takeRate, startTime))
 	}

--- a/x/alliance/tests/simulation/operations.go
+++ b/x/alliance/tests/simulation/operations.go
@@ -16,8 +16,7 @@ import (
 )
 
 // WeightedOperations returns all the operations from the module with their respective weights
-func WeightedOperations(
-	appParams simtypes.AppParams, cdc *codec.ProtoCodec,
+func WeightedOperations(cdc *codec.ProtoCodec,
 	ak types.AccountKeeper, bk types.BankKeeper,
 	sk types.StakingKeeper, k keeper.Keeper,
 ) simulation.WeightedOperations {
@@ -44,11 +43,11 @@ func WeightedOperations(
 		),
 		simulation.NewWeightedOperation(
 			weightMsgUndelegate,
-			SimulateMsgUndelegate(cdc, ak, bk, sk, k),
+			SimulateMsgUndelegate(cdc, ak, bk, k),
 		),
 		simulation.NewWeightedOperation(
 			weightMsgClaimRewards,
-			SimulateMsgClaimRewards(cdc, ak, bk, sk, k),
+			SimulateMsgClaimRewards(cdc, ak, bk, k),
 		),
 	}
 }
@@ -169,7 +168,7 @@ func SimulateMsgRedelegate(cdc *codec.ProtoCodec, ak types.AccountKeeper, bk typ
 	}
 }
 
-func SimulateMsgUndelegate(cdc *codec.ProtoCodec, ak types.AccountKeeper, bk types.BankKeeper, sk types.StakingKeeper, k keeper.Keeper) simtypes.Operation {
+func SimulateMsgUndelegate(cdc *codec.ProtoCodec, ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainId string) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
 		var delegations []types.Delegation
 		k.IterateDelegations(ctx, func(d types.Delegation) bool {
@@ -230,7 +229,7 @@ func SimulateMsgUndelegate(cdc *codec.ProtoCodec, ak types.AccountKeeper, bk typ
 	}
 }
 
-func SimulateMsgClaimRewards(cdc *codec.ProtoCodec, ak types.AccountKeeper, bk types.BankKeeper, sk types.StakingKeeper, k keeper.Keeper) simtypes.Operation {
+func SimulateMsgClaimRewards(cdc *codec.ProtoCodec, ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainId string) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
 		var delegations []types.Delegation
 		k.IterateDelegations(ctx, func(d types.Delegation) bool {

--- a/x/alliance/tests/simulation/params.go
+++ b/x/alliance/tests/simulation/params.go
@@ -10,7 +10,7 @@ import (
 	"github.com/terra-money/alliance/x/alliance/types"
 )
 
-func ParamChanges(r *rand.Rand) []simtypes.ParamChange {
+func ParamChanges() []simtypes.ParamChange {
 	return []simtypes.ParamChange{
 		simulation.NewSimParamChange(types.ModuleName, string(types.RewardDelayTime),
 			func(r *rand.Rand) string {


### PR DESCRIPTION
Fixes: https://github.com/terra-money/alliance/issues/156

When simulation parameters use a take rate that is too high (the current configuration was 0.5^17520 = 1e-5273% APY), total tokens decay too fast before any delegators can stake. 