### PR TITLE
feat: wasm bindings

### DIFF
--- a/x/alliance/bindings/query_plugin.go
+++ b/x/alliance/bindings/query_plugin.go
@@ -1,0 +1,140 @@
+package bindings
+
+import (
+	"encoding/json"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/terra-money/alliance/x/alliance/bindings/types"
+	"github.com/terra-money/alliance/x/alliance/keeper"
+	alliancetypes "github.com/terra-money/alliance/x/alliance/types"
+)
+
+type QueryPlugin struct {
+	allianceKeeper keeper.Keeper
+}
+
+func NewAllianceQueryPlugin(keeper keeper.Keeper) *QueryPlugin {
+	return &QueryPlugin{
+		allianceKeeper: keeper,
+	}
+}
+
+func CustomQuerier(q *QueryPlugin) func(ctx sdk.Context, request json.RawMessage) (result []byte, err error) {
+	return func(ctx sdk.Context, request json.RawMessage) (result []byte, err error) {
+		var AllianceRequest types.AllianceQuery
+		err = json.Unmarshal(request, &AllianceRequest)
+		if err != nil {
+			return
+		}
+		if AllianceRequest.Alliance != nil {
+			return q.GetAlliance(ctx, AllianceRequest.Alliance.Denom)
+		}
+		if AllianceRequest.Delegation != nil {
+			return q.GetDelegation(ctx, AllianceRequest.Delegation.Denom, AllianceRequest.Delegation.Delegator, AllianceRequest.Delegation.Validator)
+		}
+		if AllianceRequest.DelegationRewards != nil {
+			return q.GetDelegationRewards(ctx, AllianceRequest.DelegationRewards.Denom, AllianceRequest.DelegationRewards.Delegator, AllianceRequest.DelegationRewards.Validator)
+		}
+		return nil, nil
+	}
+}
+
+func (q *QueryPlugin) GetAlliance(ctx sdk.Context, denom string) (res []byte, err error) {
+	asset, found := q.allianceKeeper.GetAssetByDenom(ctx, denom)
+	if !found {
+		return nil, alliancetypes.ErrUnknownAsset
+	}
+	res, err = json.Marshal(types.AllianceResponse{
+		Denom:                asset.Denom,
+		RewardWeight:         asset.RewardWeight.String(),
+		TakeRate:             asset.TakeRate.String(),
+		TotalTokens:          asset.TotalTokens.String(),
+		TotalValidatorShares: asset.TotalValidatorShares.String(),
+		RewardStartTime:      uint64(asset.RewardStartTime.Nanosecond()),
+		RewardChangeRate:     asset.RewardChangeRate.String(),
+		LastRewardChangeTime: uint64(asset.LastRewardChangeTime.Nanosecond()),
+		RewardWeightRange: types.RewardWeightRange{
+			Min: asset.RewardWeightRange.Min.String(),
+			Max: asset.RewardWeightRange.Max.String(),
+		},
+		IsInitialized: asset.IsInitialized,
+	})
+	return
+}
+
+func (q *QueryPlugin) GetDelegation(ctx sdk.Context, denom string, delegator string, validator string) (res []byte, err error) {
+	delegatorAddr, err := sdk.AccAddressFromBech32(delegator)
+	if err != nil {
+		return
+	}
+	validatorAddr, err := sdk.ValAddressFromBech32(validator)
+	if err != nil {
+		return
+	}
+	delegation, found := q.allianceKeeper.GetDelegation(ctx, delegatorAddr, validatorAddr, denom)
+	if !found {
+		return nil, alliancetypes.ErrDelegationNotFound
+	}
+	asset, found := q.allianceKeeper.GetAssetByDenom(ctx, denom)
+	if !found {
+		return nil, alliancetypes.ErrUnknownAsset
+	}
+
+	allianceValidator, err := q.allianceKeeper.GetAllianceValidator(ctx, validatorAddr)
+	if err != nil {
+		return nil, err
+	}
+	balance := alliancetypes.GetDelegationTokens(delegation, allianceValidator, asset)
+	res, err = json.Marshal(types.DelegationResponse{
+		Delegator: delegation.DelegatorAddress,
+		Validator: delegation.ValidatorAddress,
+		Denom:     delegation.Denom,
+		Amount: types.Coin{
+			Denom:  balance.Denom,
+			Amount: balance.Amount.String(),
+		},
+	})
+	return res, err
+}
+
+func (q *QueryPlugin) GetDelegationRewards(ctx sdk.Context, denom string, delegator string, validator string) (res []byte, err error) {
+	delegatorAddr, err := sdk.AccAddressFromBech32(delegator)
+	if err != nil {
+		return
+	}
+	validatorAddr, err := sdk.ValAddressFromBech32(validator)
+	if err != nil {
+		return
+	}
+	delegation, found := q.allianceKeeper.GetDelegation(ctx, delegatorAddr, validatorAddr, denom)
+	if !found {
+		return nil, alliancetypes.ErrDelegationNotFound
+	}
+	allianceValidator, err := q.allianceKeeper.GetAllianceValidator(ctx, validatorAddr)
+	if err != nil {
+		return nil, err
+	}
+	asset, found := q.allianceKeeper.GetAssetByDenom(ctx, denom)
+	if !found {
+		return nil, alliancetypes.ErrUnknownAsset
+	}
+
+	rewards, _, err := q.allianceKeeper.CalculateDelegationRewards(ctx, delegation, allianceValidator, asset)
+	if err != nil {
+		return
+	}
+
+	var coins []types.Coin
+	for _, coin := range rewards {
+		coins = append(coins, types.Coin{
+			Denom:  coin.Denom,
+			Amount: coin.Amount.String(),
+		})
+	}
+
+	res, err = json.Marshal(types.DelegationRewardsResponse{
+		Rewards: coins,
+	})
+	return res, err
+}

--- a/x/alliance/bindings/tests/query_plugin_test.go
+++ b/x/alliance/bindings/tests/query_plugin_test.go
@@ -1,0 +1,205 @@
+package bindings_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/terra-money/alliance/app"
+	"github.com/terra-money/alliance/x/alliance/bindings"
+	bindingtypes "github.com/terra-money/alliance/x/alliance/bindings/types"
+	"github.com/terra-money/alliance/x/alliance/types"
+)
+
+func createTestContext(t *testing.T) (*app.App, sdk.Context) {
+	app := app.Setup(t)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+	return app, ctx
+}
+
+var AllianceDenom = "alliance"
+
+func TestAssetQuery(t *testing.T) {
+	app, ctx := createTestContext(t)
+	genesisTime := ctx.BlockTime()
+	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
+		Params: types.DefaultParams(),
+		Assets: []types.AllianceAsset{
+			types.NewAllianceAsset(AllianceDenom, sdk.NewDec(2), sdk.ZeroDec(), sdk.NewDec(5), sdk.NewDec(0), genesisTime),
+		},
+	})
+
+	querierPlugin := bindings.NewAllianceQueryPlugin(app.AllianceKeeper)
+	querier := bindings.CustomQuerier(querierPlugin)
+
+	assetQuery := bindingtypes.AllianceQuery{
+		Alliance: &bindingtypes.Alliance{
+			Denom: AllianceDenom,
+		},
+	}
+	qBz, err := json.Marshal(assetQuery)
+	require.NoError(t, err)
+	rBz, err := querier(ctx, qBz)
+	require.NoError(t, err)
+
+	var assetResponse bindingtypes.AllianceResponse
+	err = json.Unmarshal(rBz, &assetResponse)
+	require.NoError(t, err)
+
+	require.Equal(t, bindingtypes.AllianceResponse{
+		Denom:                AllianceDenom,
+		RewardWeight:         sdk.MustNewDecFromStr("2").String(),
+		TakeRate:             sdk.MustNewDecFromStr("0").String(),
+		TotalTokens:          "0",
+		TotalValidatorShares: sdk.MustNewDecFromStr("0").String(),
+		RewardStartTime:      uint64(genesisTime.Nanosecond()),
+		RewardChangeRate:     sdk.MustNewDecFromStr("1").String(),
+		LastRewardChangeTime: 0,
+		RewardWeightRange: bindingtypes.RewardWeightRange{
+			Min: sdk.MustNewDecFromStr("0").String(),
+			Max: sdk.MustNewDecFromStr("5").String(),
+		},
+		IsInitialized: false,
+	}, assetResponse)
+}
+
+func TestDelegationQuery(t *testing.T) {
+	app, ctx := createTestContext(t)
+	genesisTime := ctx.BlockTime()
+	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
+		Params: types.DefaultParams(),
+		Assets: []types.AllianceAsset{
+			types.NewAllianceAsset(AllianceDenom, sdk.NewDec(2), sdk.ZeroDec(), sdk.NewDec(5), sdk.NewDec(0), genesisTime),
+		},
+	})
+	delegations := app.StakingKeeper.GetAllDelegations(ctx)
+	require.Len(t, delegations, 1)
+	// All the addresses needed
+	delAddr, err := sdk.AccAddressFromBech32(delegations[0].DelegatorAddress)
+	require.NoError(t, err)
+	valAddr, err := sdk.ValAddressFromBech32(delegations[0].ValidatorAddress)
+	require.NoError(t, err)
+	val, err := app.AllianceKeeper.GetAllianceValidator(ctx, valAddr)
+	require.NoError(t, err)
+
+	// Mint alliance tokens
+	err = app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin(AllianceDenom, sdk.NewInt(2000_000))))
+	require.NoError(t, err)
+	err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, delAddr, sdk.NewCoins(sdk.NewCoin(AllianceDenom, sdk.NewInt(2000_000))))
+	require.NoError(t, err)
+
+	// Check current total staked tokens
+	totalBonded := app.StakingKeeper.TotalBondedTokens(ctx)
+	require.Equal(t, sdk.NewInt(1000_000), totalBonded)
+
+	// Delegate
+	_, err = app.AllianceKeeper.Delegate(ctx, delAddr, val, sdk.NewCoin(AllianceDenom, sdk.NewInt(1000_000)))
+	require.NoError(t, err)
+
+	querierPlugin := bindings.NewAllianceQueryPlugin(app.AllianceKeeper)
+	querier := bindings.CustomQuerier(querierPlugin)
+
+	delegationQuery := bindingtypes.AllianceQuery{
+		Delegation: &bindingtypes.Delegation{
+			Delegator: delAddr.String(),
+			Validator: val.GetOperator().String(),
+			Denom:     AllianceDenom,
+		},
+	}
+	qBz, err := json.Marshal(delegationQuery)
+	require.NoError(t, err)
+	rBz, err := querier(ctx, qBz)
+	require.NoError(t, err)
+
+	var delegationResponse bindingtypes.DelegationResponse
+	err = json.Unmarshal(rBz, &delegationResponse)
+	require.NoError(t, err)
+
+	require.Equal(t, bindingtypes.DelegationResponse{
+		Delegator: delAddr.String(),
+		Validator: val.GetOperator().String(),
+		Denom:     AllianceDenom,
+		Amount: bindingtypes.Coin{
+			Denom:  AllianceDenom,
+			Amount: "1000000",
+		},
+	}, delegationResponse)
+}
+
+func TestDelegationRewardsQuery(t *testing.T) {
+	app, ctx := createTestContext(t)
+	genesisTime := ctx.BlockTime()
+	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
+		Params: types.DefaultParams(),
+		Assets: []types.AllianceAsset{
+			types.NewAllianceAsset(AllianceDenom, sdk.NewDec(2), sdk.ZeroDec(), sdk.NewDec(5), sdk.NewDec(0), genesisTime),
+		},
+	})
+	delegations := app.StakingKeeper.GetAllDelegations(ctx)
+	require.Len(t, delegations, 1)
+	// All the addresses needed
+	delAddr, err := sdk.AccAddressFromBech32(delegations[0].DelegatorAddress)
+	require.NoError(t, err)
+	valAddr, err := sdk.ValAddressFromBech32(delegations[0].ValidatorAddress)
+	require.NoError(t, err)
+	val, err := app.AllianceKeeper.GetAllianceValidator(ctx, valAddr)
+	require.NoError(t, err)
+
+	// Mint alliance tokens
+	err = app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin(AllianceDenom, sdk.NewInt(2000_000))))
+	require.NoError(t, err)
+	err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, delAddr, sdk.NewCoins(sdk.NewCoin(AllianceDenom, sdk.NewInt(2000_000))))
+	require.NoError(t, err)
+
+	// Check current total staked tokens
+	totalBonded := app.StakingKeeper.TotalBondedTokens(ctx)
+	require.Equal(t, sdk.NewInt(1000_000), totalBonded)
+
+	// Delegate
+	_, err = app.AllianceKeeper.Delegate(ctx, delAddr, val, sdk.NewCoin(AllianceDenom, sdk.NewInt(1000_000)))
+	require.NoError(t, err)
+
+	assets := app.AllianceKeeper.GetAllAssets(ctx)
+	err = app.AllianceKeeper.RebalanceBondTokenWeights(ctx, assets)
+	require.NoError(t, err)
+
+	// Transfer to reward pool
+	mintPoolAddr := app.AccountKeeper.GetModuleAddress(minttypes.ModuleName)
+	err = app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(4000_000))))
+	require.NoError(t, err)
+	err = app.AllianceKeeper.AddAssetsToRewardPool(ctx, mintPoolAddr, val, sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(2000_000))))
+	require.NoError(t, err)
+
+	querierPlugin := bindings.NewAllianceQueryPlugin(app.AllianceKeeper)
+	querier := bindings.CustomQuerier(querierPlugin)
+
+	delegationQuery := bindingtypes.AllianceQuery{
+		DelegationRewards: &bindingtypes.DelegationRewards{
+			Delegator: delAddr.String(),
+			Validator: val.GetOperator().String(),
+			Denom:     AllianceDenom,
+		},
+	}
+	qBz, err := json.Marshal(delegationQuery)
+	require.NoError(t, err)
+	rBz, err := querier(ctx, qBz)
+	require.NoError(t, err)
+
+	var response bindingtypes.DelegationRewardsResponse
+	err = json.Unmarshal(rBz, &response)
+	require.NoError(t, err)
+
+	require.Equal(t, bindingtypes.DelegationRewardsResponse{
+		Rewards: []bindingtypes.Coin{
+			{
+				Denom:  "stake",
+				Amount: "2000000",
+			},
+		},
+	}, response)
+}

--- a/x/alliance/bindings/types/request.go
+++ b/x/alliance/bindings/types/request.go
@@ -1,0 +1,23 @@
+package types
+
+type AllianceQuery struct {
+	Alliance          *Alliance          `json:"alliance"`
+	Delegation        *Delegation        `json:"delegation"`
+	DelegationRewards *DelegationRewards `json:"delegation_rewards"`
+}
+
+type Alliance struct {
+	Denom string `json:"denom"`
+}
+
+type Delegation struct {
+	Denom     string `json:"denom"`
+	Delegator string `json:"delegator"`
+	Validator string `json:"validator"`
+}
+
+type DelegationRewards struct {
+	Denom     string `json:"denom"`
+	Delegator string `json:"delegator"`
+	Validator string `json:"validator"`
+}

--- a/x/alliance/bindings/types/response.go
+++ b/x/alliance/bindings/types/response.go
@@ -1,0 +1,35 @@
+package types
+
+type AllianceResponse struct {
+	Denom                string            `json:"denom"`
+	RewardWeight         string            `json:"reward_weight"`
+	TakeRate             string            `json:"take_rate"`
+	TotalTokens          string            `json:"total_tokens"`
+	TotalValidatorShares string            `json:"total_validator_shares"`
+	RewardStartTime      uint64            `json:"reward_start_time"`
+	RewardChangeRate     string            `json:"reward_change_rate"`
+	LastRewardChangeTime uint64            `json:"last_reward_change_time"`
+	RewardWeightRange    RewardWeightRange `json:"reward_weight_range"`
+	IsInitialized        bool              `json:"is_initialized"`
+}
+
+type RewardWeightRange struct {
+	Min string `json:"min"`
+	Max string `json:"max"`
+}
+
+type Coin struct {
+	Denom  string `json:"denom"`
+	Amount string `json:"amount"`
+}
+
+type DelegationResponse struct {
+	Delegator string `json:"delegator"`
+	Validator string `json:"validator"`
+	Denom     string `json:"denom"`
+	Amount    Coin   `json:"amount"`
+}
+
+type DelegationRewardsResponse struct {
+	Rewards []Coin `json:"rewards"`
+}

--- a/x/alliance/types/errors.go
+++ b/x/alliance/types/errors.go
@@ -9,6 +9,7 @@ var (
 
 	ErrEmptyValidatorAddr = sdkerrors.Register(ModuleName, 10, "empty validator address")
 	ErrValidatorNotFound  = sdkerrors.Register(ModuleName, 11, "validator not found")
+	ErrDelegationNotFound = sdkerrors.Register(ModuleName, 12, "delegation not found")
 
 	ErrZeroDelegations    = sdkerrors.Register(ModuleName, 20, "there are no delegations yet")
 	ErrInsufficientTokens = sdkerrors.Register(ModuleName, 21, "insufficient tokens")


### PR DESCRIPTION
This PR adds wasm bindings to the alliance module for wasm contracts to be able to query alliance state. 
Related issue https://github.com/terra-money/alliance/issues/165