### PR TITLE
fix: skip reward distribution when there are no delegators

### DIFF
--- a/cmd/allianced/cmd/cmd_test.go
+++ b/cmd/allianced/cmd/cmd_test.go
@@ -6,28 +6,28 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"cosmossdk.io/simapp"
-	"cosmossdk.io/simapp/simd/cmd"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	"github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
+
+	"github.com/terra-money/alliance/app"
+	"github.com/terra-money/alliance/cmd/allianced/cmd"
 )
 
 func TestInitCmd(t *testing.T) {
-	rootCmd := cmd.NewRootCmd()
+	rootCmd, _ := cmd.NewRootCmd()
 	rootCmd.SetArgs([]string{
 		"init",        // Test the init cmd
 		"simapp-test", // Moniker
 		fmt.Sprintf("--%s=%s", cli.FlagOverwrite, "true"), // Overwrite genesis.json, in case it already exists
 	})
-
-	require.NoError(t, svrcmd.Execute(rootCmd, "", simapp.DefaultNodeHome))
+	require.NoError(t, svrcmd.Execute(rootCmd, "", app.DefaultNodeHome))
 }
 
 func TestHomeFlagRegistration(t *testing.T) {
 	homeDir := "/tmp/foo"
 
-	rootCmd := cmd.NewRootCmd()
+	rootCmd, _ := cmd.NewRootCmd()
 
 	rootCmd.SetArgs([]string{
 		"query",
@@ -35,7 +35,7 @@ func TestHomeFlagRegistration(t *testing.T) {
 		homeDir,
 	})
 
-	require.NoError(t, svrcmd.Execute(rootCmd, "", simapp.DefaultNodeHome))
+	require.NoError(t, svrcmd.Execute(rootCmd, "", app.DefaultNodeHome))
 
 	result, err := rootCmd.Flags().GetString(flags.FlagHome)
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.0
-	cosmossdk.io/simapp v0.0.0-20230224204036-a6adb0821462
 	cosmossdk.io/tools/rosetta v0.2.1
 	github.com/cometbft/cometbft v0.37.0
 	github.com/cometbft/cometbft-db v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,6 @@ cosmossdk.io/errors v1.0.0-beta.7 h1:gypHW76pTQGVnHKo6QBkb4yFOJjC+sUGRc5Al3Odj1w
 cosmossdk.io/errors v1.0.0-beta.7/go.mod h1:mz6FQMJRku4bY7aqS/Gwfcmr/ue91roMEKAmDUDpBfE=
 cosmossdk.io/math v1.0.0 h1:ro9w7eKx23om2tZz/VM2Pf+z2WAbGX1yDQQOJ6iGeJw=
 cosmossdk.io/math v1.0.0/go.mod h1:Ygz4wBHrgc7g0N+8+MrnTfS9LLn9aaTGa9hKopuym5k=
-cosmossdk.io/simapp v0.0.0-20230224204036-a6adb0821462 h1:g8muUHnXL8vhld2Sjilyhb1UQObc+x9GVuDK43TYZns=
-cosmossdk.io/simapp v0.0.0-20230224204036-a6adb0821462/go.mod h1:4Dd3NLoLYoN90kZ0uyHoTHzVVk9+J0v4HhZRBNTAq2c=
 cosmossdk.io/tools/rosetta v0.2.1 h1:ddOMatOH+pbxWbrGJKRAawdBkPYLfKXutK9IETnjYxw=
 cosmossdk.io/tools/rosetta v0.2.1/go.mod h1:Pqdc1FdvkNV3LcNIkYWt2RQY6IP1ge6YWZk8MhhO9Hw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=

--- a/x/alliance/client/cli/gov.go
+++ b/x/alliance/client/cli/gov.go
@@ -23,7 +23,7 @@ func CreateAlliance() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			title, err := cmd.Flags().GetString(govcli.FlagTitle) //nolint:staticcheck // SA1019: govcli.FlagTitle is deprecated
+			title, err := cmd.Flags().GetString(govcli.FlagTitle)
 			if err != nil {
 				return err
 			}
@@ -110,7 +110,7 @@ func CreateAlliance() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String(govcli.FlagTitle, "", "title of proposal")             //nolint:staticcheck
+	cmd.Flags().String(govcli.FlagTitle, "", "title of proposal")
 	cmd.Flags().String(govcli.FlagDescription, "", "description of proposal") //nolint:staticcheck
 	cmd.Flags().String(govcli.FlagDeposit, "", "deposit of proposal")
 	return cmd
@@ -126,7 +126,7 @@ func UpdateAlliance() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			title, err := cmd.Flags().GetString(govcli.FlagTitle) //nolint:staticcheck
+			title, err := cmd.Flags().GetString(govcli.FlagTitle)
 			if err != nil {
 				return err
 			}
@@ -199,7 +199,7 @@ func UpdateAlliance() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String(govcli.FlagTitle, "", "title of proposal")             //nolint:staticcheck // SA1019: govcli.FlagTitle is deprecated
+	cmd.Flags().String(govcli.FlagTitle, "", "title of proposal")
 	cmd.Flags().String(govcli.FlagDescription, "", "description of proposal") //nolint:staticcheck // SA1019: govcli.FlagDescription is deprecated
 	cmd.Flags().String(govcli.FlagDeposit, "", "deposit of proposal")
 	return cmd
@@ -215,7 +215,7 @@ func DeleteAlliance() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			title, err := cmd.Flags().GetString(govcli.FlagTitle) //nolint:staticcheck // SA1019: govcli.FlagTitle is deprecated
+			title, err := cmd.Flags().GetString(govcli.FlagTitle)
 			if err != nil {
 				return err
 			}
@@ -264,7 +264,7 @@ func DeleteAlliance() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String(govcli.FlagTitle, "", "title of proposal")             //nolint:staticcheck // SA1019: govcli.FlagTitle is deprecated: use FlagTitle instead
+	cmd.Flags().String(govcli.FlagTitle, "", "title of proposal")
 	cmd.Flags().String(govcli.FlagDescription, "", "description of proposal") //nolint:staticcheck // SA1019: govcli.FlagDescription is deprecated: use FlagDescription instead
 	cmd.Flags().String(govcli.FlagDeposit, "", "deposit of proposal")
 	return cmd

--- a/x/alliance/keeper/reward.go
+++ b/x/alliance/keeper/reward.go
@@ -131,10 +131,15 @@ func accumulateRewards(latestRewardHistories types.RewardHistories, rewardHistor
 // To calculate the number of rewards claimable, take reward_history * alliance_token_amount * reward_weight
 func (k Keeper) AddAssetsToRewardPool(ctx sdk.Context, from sdk.AccAddress, val types.AllianceValidator, coins sdk.Coins) error {
 	rewardHistories := types.NewRewardHistories(val.GlobalRewardHistory)
+	// We need some delegations before we can split rewards. Else rewards belong to no one and do nothing
+	if len(val.TotalDelegatorShares) == 0 {
+		return nil
+	}
+
 	totalAssetWeight := k.totalAssetWeight(ctx, val)
-	// We need some delegations before we can split rewards. Else rewards belong to no one
 	if totalAssetWeight.IsZero() {
-		return types.ErrZeroDelegations
+		// Do nothing since there are no assets to distribute rewards to
+		return nil
 	}
 
 	for _, c := range coins {

--- a/x/alliance/keeper/tests/reward_test.go
+++ b/x/alliance/keeper/tests/reward_test.go
@@ -62,10 +62,6 @@ func TestRewardPoolAndGlobalIndex(t *testing.T) {
 	coin := app.BankKeeper.GetBalance(ctx, mintPoolAddr, "stake")
 	require.Equal(t, sdk.NewCoin("stake", sdk.NewInt(4000_000)), coin)
 
-	// Transfer to reward pool without delegations will fail
-	err = app.AllianceKeeper.AddAssetsToRewardPool(ctx, mintPoolAddr, val1, sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(2000_000))))
-	require.Error(t, err)
-
 	_, err = app.AllianceKeeper.Delegate(ctx, user1, val1, sdk.NewCoin(AllianceDenom, sdk.NewInt(1000_000)))
 	require.NoError(t, err)
 	assets := app.AllianceKeeper.GetAllAssets(ctx)

--- a/x/alliance/keeper/tests/reward_test.go
+++ b/x/alliance/keeper/tests/reward_test.go
@@ -903,3 +903,83 @@ func TestClaimRewardsAfterRebalancing(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rewards, 1)
 }
+
+func TestRewardWeightWithZeroTokens(t *testing.T) {
+	var err error
+	app, ctx := createTestContext(t)
+	mintPoolAddr := app.AccountKeeper.GetModuleAddress(minttypes.ModuleName)
+	startTime := time.Now()
+	ctx = ctx.WithBlockTime(startTime)
+	app.AllianceKeeper.InitGenesis(ctx, &types.GenesisState{
+		Params: types.DefaultParams(),
+		Assets: []types.AllianceAsset{
+			types.NewAllianceAsset(AllianceDenom, sdk.NewDec(2), sdk.NewDec(0), sdk.NewDec(5), sdk.NewDec(0), ctx.BlockTime()),
+			types.NewAllianceAsset(AllianceDenomTwo, sdk.NewDec(10), sdk.NewDec(2), sdk.NewDec(12), sdk.NewDec(0), ctx.BlockTime()),
+		},
+	})
+
+	// Set tax and rewards to be zero for easier calculation
+	distParams := app.DistrKeeper.GetParams(ctx)
+	distParams.CommunityTax = sdk.ZeroDec()
+
+	err = app.DistrKeeper.SetParams(ctx, distParams)
+	require.NoError(t, err)
+
+	// Accounts
+	addrs := test_helpers.AddTestAddrsIncremental(app, ctx, 4, sdk.NewCoins(
+		sdk.NewCoin(AllianceDenom, sdk.NewInt(20_000_000)),
+	))
+	pks := test_helpers.CreateTestPubKeys(2)
+
+	// Creating two validators: 1 with 0% commission, 1 with 100% commission
+	valAddr1 := sdk.ValAddress(addrs[0])
+	_val1 := teststaking.NewValidator(t, valAddr1, pks[0])
+	_val1.Commission = stakingtypes.Commission{
+		CommissionRates: stakingtypes.CommissionRates{
+			Rate:          sdk.NewDec(0),
+			MaxRate:       sdk.NewDec(0),
+			MaxChangeRate: sdk.NewDec(0),
+		},
+		UpdateTime: time.Now(),
+	}
+	test_helpers.RegisterNewValidator(t, app, ctx, _val1)
+	user1 := addrs[2]
+	val1, _ := app.AllianceKeeper.GetAllianceValidator(ctx, valAddr1)
+
+	// Mint tokens
+	err = app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(4000_000))))
+	require.NoError(t, err)
+
+	// New delegation from user 1
+	_, err = app.AllianceKeeper.Delegate(ctx, user1, val1, sdk.NewCoin(AllianceDenom, sdk.NewInt(1000_000)))
+	require.NoError(t, err)
+
+	// Apply take weight to reduce tokens in asset
+	asset, found := app.AllianceKeeper.GetAssetByDenom(ctx, AllianceDenom)
+	require.True(t, found)
+	asset.TotalTokens = sdk.NewInt(1)
+	app.AllianceKeeper.SetAsset(ctx, asset)
+
+	// New delegation from user 1
+	_, err = app.AllianceKeeper.Delegate(ctx, user1, val1, sdk.NewCoin(AllianceDenom, sdk.NewInt(1000_000)))
+	require.NoError(t, err)
+
+	// Apply take weight to reduce tokens in asset
+	asset, found = app.AllianceKeeper.GetAssetByDenom(ctx, AllianceDenom)
+	require.True(t, found)
+	asset.TotalTokens = sdk.NewInt(0)
+	app.AllianceKeeper.SetAsset(ctx, asset)
+
+	// Before transfer to reward pool
+	beforeMintPoolAmount := app.BankKeeper.GetBalance(ctx, mintPoolAddr, AllianceDenom)
+	require.NoError(t, err)
+
+	// Transfer to reward pool
+	err = app.AllianceKeeper.AddAssetsToRewardPool(ctx, mintPoolAddr, val1, sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(2000_000))))
+	require.NoError(t, err)
+
+	afterMintPoolAmount := app.BankKeeper.GetBalance(ctx, mintPoolAddr, AllianceDenom)
+	require.NoError(t, err)
+
+	require.Equal(t, beforeMintPoolAmount, afterMintPoolAmount)
+}

--- a/x/alliance/tests/simulation/operations.go
+++ b/x/alliance/tests/simulation/operations.go
@@ -3,7 +3,8 @@ package simulation
 import (
 	"math/rand"
 
-	simappparams "cosmossdk.io/simapp/params"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -82,7 +83,7 @@ func SimulateMsgDelegate(cdc *codec.ProtoCodec, ak types.AccountKeeper, bk types
 		txCtx := simulation.OperationInput{
 			R:               r,
 			App:             app,
-			TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
+			TxGen:           tx.NewTxConfig(cdc, tx.DefaultSignModes),
 			Cdc:             cdc,
 			Msg:             msg,
 			MsgType:         msg.Type(),
@@ -153,7 +154,7 @@ func SimulateMsgRedelegate(cdc *codec.ProtoCodec, ak types.AccountKeeper, bk typ
 		txCtx := simulation.OperationInput{
 			R:             r,
 			App:           app,
-			TxGen:         simappparams.MakeTestEncodingConfig().TxConfig,
+			TxGen:         tx.NewTxConfig(cdc, tx.DefaultSignModes),
 			Cdc:           cdc,
 			Msg:           msg,
 			MsgType:       msg.Type(),
@@ -214,7 +215,7 @@ func SimulateMsgUndelegate(cdc *codec.ProtoCodec, ak types.AccountKeeper, bk typ
 		txCtx := simulation.OperationInput{
 			R:             r,
 			App:           app,
-			TxGen:         simappparams.MakeTestEncodingConfig().TxConfig,
+			TxGen:         tx.NewTxConfig(cdc, tx.DefaultSignModes),
 			Cdc:           cdc,
 			Msg:           msg,
 			MsgType:       msg.Type(),
@@ -262,7 +263,7 @@ func SimulateMsgClaimRewards(cdc *codec.ProtoCodec, ak types.AccountKeeper, bk t
 		txCtx := simulation.OperationInput{
 			R:             r,
 			App:           app,
-			TxGen:         simappparams.MakeTestEncodingConfig().TxConfig,
+			TxGen:         tx.NewTxConfig(cdc, tx.DefaultSignModes),
 			Cdc:           cdc,
 			Msg:           msg,
 			MsgType:       msg.Type(),


### PR DESCRIPTION
When delegators undelegate all assets, there could be edge case when rewards are still distributed and this causes a panic when rebalancing assets. 