### PR TITLE
fix: bank msg server interface error

### DIFF
--- a/cmd/allianced/cmd/testnet.go
+++ b/cmd/allianced/cmd/testnet.go
@@ -296,10 +296,11 @@ func initTestnetFiles(
 
 		genBalances = append(genBalances, banktypes.Balance{Address: addr.String(), Coins: coins.Sort()})
 		genAccounts = append(genAccounts, authtypes.NewBaseAccount(addr, nil, 0, 0))
+		valAddr := sdk.ValAddress(addr)
 
 		valTokens := sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction)
 		createValMsg, err := stakingtypes.NewMsgCreateValidator(
-			addr.String(),
+			valAddr.String(),
 			valPubKeys[i],
 			sdk.NewCoin(sdk.DefaultBondDenom, valTokens),
 			stakingtypes.NewDescription(nodeDirName, "", "", "", ""),

--- a/custom/bank/keeper/msg_server.go
+++ b/custom/bank/keeper/msg_server.go
@@ -1,0 +1,124 @@
+package keeper
+
+import (
+	"context"
+	"cosmossdk.io/core/address"
+	errorsmod "cosmossdk.io/errors"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/cosmos/cosmos-sdk/telemetry"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	"github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/hashicorp/go-metrics"
+)
+
+type msgServer struct {
+	types.MsgServer
+
+	keeper       bankkeeper.Keeper
+	addressCodec address.Codec
+}
+
+var _ types.MsgServer = msgServer{}
+
+func NewMsgServerImpl(keeper Keeper, addressCodec address.Codec) types.MsgServer {
+	return &msgServer{
+		MsgServer:    bankkeeper.NewMsgServerImpl(keeper),
+		keeper:       keeper,
+		addressCodec: addressCodec,
+	}
+}
+
+func (k msgServer) Send(goCtx context.Context, msg *types.MsgSend) (*types.MsgSendResponse, error) {
+
+	from, err := k.addressCodec.StringToBytes(msg.FromAddress)
+	if err != nil {
+		return nil, sdkerrors.ErrInvalidAddress.Wrapf("invalid from address: %s", err)
+	}
+	to, err := k.addressCodec.StringToBytes(msg.ToAddress)
+	if err != nil {
+		return nil, sdkerrors.ErrInvalidAddress.Wrapf("invalid to address: %s", err)
+	}
+
+	if !msg.Amount.IsValid() {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
+	}
+
+	if !msg.Amount.IsAllPositive() {
+		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
+	}
+
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	if err := k.keeper.IsSendEnabledCoins(ctx, msg.Amount...); err != nil {
+		return nil, err
+	}
+
+	if k.keeper.BlockedAddr(to) {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", msg.ToAddress)
+	}
+
+	err = k.keeper.SendCoins(ctx, from, to, msg.Amount)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		for _, a := range msg.Amount {
+			if a.Amount.IsInt64() {
+				telemetry.SetGaugeWithLabels(
+					[]string{"tx", "msg", "send"},
+					float32(a.Amount.Int64()),
+					[]metrics.Label{telemetry.NewLabel("denom", a.Denom)},
+				)
+			}
+		}
+	}()
+
+	return &types.MsgSendResponse{}, nil
+}
+
+func (k msgServer) MultiSend(goCtx context.Context, msg *types.MsgMultiSend) (*types.MsgMultiSendResponse, error) {
+	if len(msg.Inputs) == 0 {
+		return nil, types.ErrNoInputs
+	}
+
+	if len(msg.Inputs) != 1 {
+		return nil, types.ErrMultipleSenders
+	}
+
+	if len(msg.Outputs) == 0 {
+		return nil, types.ErrNoOutputs
+	}
+
+	if err := types.ValidateInputOutputs(msg.Inputs[0], msg.Outputs); err != nil {
+		return nil, err
+	}
+
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	// NOTE: totalIn == totalOut should already have been checked
+	for _, in := range msg.Inputs {
+		if err := k.keeper.IsSendEnabledCoins(ctx, in.Coins...); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, out := range msg.Outputs {
+		accAddr, err := k.addressCodec.StringToBytes(out.Address)
+		if err != nil {
+			return nil, err
+		}
+
+		if k.keeper.BlockedAddr(accAddr) {
+			return nil, errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", out.Address)
+		}
+	}
+
+	err := k.keeper.InputOutputCoins(ctx, msg.Inputs[0], msg.Outputs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.MsgMultiSendResponse{}, nil
+}

--- a/custom/bank/keeper/msg_server.go
+++ b/custom/bank/keeper/msg_server.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+
 	"cosmossdk.io/core/address"
 	errorsmod "cosmossdk.io/errors"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -31,7 +32,6 @@ func NewMsgServerImpl(keeper Keeper, addressCodec address.Codec) types.MsgServer
 }
 
 func (k msgServer) Send(goCtx context.Context, msg *types.MsgSend) (*types.MsgSendResponse, error) {
-
 	from, err := k.addressCodec.StringToBytes(msg.FromAddress)
 	if err != nil {
 		return nil, sdkerrors.ErrInvalidAddress.Wrapf("invalid from address: %s", err)

--- a/custom/bank/module.go
+++ b/custom/bank/module.go
@@ -1,6 +1,7 @@
 package bank
 
 import (
+	"cosmossdk.io/core/address"
 	"fmt"
 
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
@@ -20,17 +21,19 @@ import (
 // It modifies the TotalSupply and SupplyOf GRPC queries
 type AppModule struct {
 	bankmodule.AppModule
-	keeper   custombankkeeper.Keeper
-	subspace exported.Subspace
+	keeper       custombankkeeper.Keeper
+	subspace     exported.Subspace
+	addressCodec address.Codec
 }
 
 // NewAppModule creates a new AppModule object
 func NewAppModule(cdc codec.Codec, keeper custombankkeeper.Keeper, accountKeeper types.AccountKeeper, ss exported.Subspace) AppModule {
 	bankModule := bankmodule.NewAppModule(cdc, keeper, accountKeeper, ss)
 	return AppModule{
-		AppModule: bankModule,
-		keeper:    keeper,
-		subspace:  ss,
+		AppModule:    bankModule,
+		keeper:       keeper,
+		subspace:     ss,
+		addressCodec: accountKeeper.AddressCodec(),
 	}
 }
 
@@ -38,7 +41,7 @@ func NewAppModule(cdc codec.Codec, keeper custombankkeeper.Keeper, accountKeeper
 // NOTE: Overriding this method as not doing so will cause a panic
 // when trying to force this custom keeper into a bankkeeper.BaseKeeper
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), bankkeeper.NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), custombankkeeper.NewMsgServerImpl(am.keeper, am.addressCodec))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
 	m := bankkeeper.NewMigrator(am.keeper.BaseKeeper, am.subspace)

--- a/custom/bank/module.go
+++ b/custom/bank/module.go
@@ -1,8 +1,9 @@
 package bank
 
 import (
-	"cosmossdk.io/core/address"
 	"fmt"
+
+	"cosmossdk.io/core/address"
 
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 


### PR DESCRIPTION
Bank module's MsgServer requires the Keeper to be of the BaseKeeper type. However, in alliance, we re-implemented the bank keeper thus the type check fails. 

```
msgServer.Send() {
    if base, ok := k.Keeper.(BaseKeeper); ok {
        from, err = base.ak.AddressCodec().StringToBytes(msg.FromAddress)
        if err != nil {
            return nil, sdkerrors.ErrInvalidAddress.Wrapf("invalid from address: %s", err)
        }
        to, err = base.ak.AddressCodec().StringToBytes(msg.ToAddress)
        if err != nil {
            return nil, sdkerrors.ErrInvalidAddress.Wrapf("invalid to address: %s", err)
        }
    } else {
        return nil, sdkerrors.ErrInvalidRequest.Wrapf("invalid keeper type: %T", k.Keeper)
    }
}
```

Updated the implementation to replace the two send functions to remove the type requirement.