### PR TITLE
fix: claim accured rewards first before adding delegation

### DIFF
--- a/x/alliance/keeper/delegation.go
+++ b/x/alliance/keeper/delegation.go
@@ -46,6 +46,12 @@ func (k Keeper) Delegate(ctx context.Context, delAddr sdk.AccAddress, validator 
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		// Claim validator rewards first to ensure that we distribute accrued rewards to delegators before the new delegation
+		_, err = k.ClaimValidatorRewards(ctx, validator)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Create or update a delegation


### PR DESCRIPTION
When a new delegation is created, we need to first claim all already accrued rewards from all previous delegations. Else, the new delegation will get a share of the old accrued rewards.