### PR TITLE
fix: change the start time used to calculate end blocker time metric

### DIFF
--- a/x/alliance/abci.go
+++ b/x/alliance/abci.go
@@ -2,6 +2,7 @@ package alliance
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/terra-money/alliance/x/alliance/keeper"
 	"github.com/terra-money/alliance/x/alliance/types"
@@ -12,7 +13,7 @@ import (
 
 // EndBlocker
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
-	defer telemetry.ModuleMeasureSince(types.ModuleName, ctx.BlockTime(), telemetry.MetricKeyEndBlocker)
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyEndBlocker)
 	k.CompleteRedelegations(ctx)
 	if err := k.CompleteUnbondings(ctx); err != nil {
 		return fmt.Errorf("failed to complete undelegations from x/alliance module: %s", err)


### PR DESCRIPTION
We found out that the metric reported for the alliance module's end-blocker time is weirdly high:

```json
{
  "Name": "end_blocker",
  "Count": 2,
  "Rate": 1244.006640625,
  "Sum": 12440.06640625,
  "Min": 6176.10205078125,
  "Max": 6263.96435546875,
  "Mean": 6220.033203125,
  "Stddev": 62.12803145520983,
  "Labels": {
    "module": "alliance"
  }
}
```

And realized that instead of using `time.Now()` as the start time for calculating the metric, block time is used, which causes this problem.